### PR TITLE
Add Ctrl+Backspace word delete

### DIFF
--- a/packages/cli/src/ui/components/shared/text-buffer.test.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer.test.ts
@@ -774,6 +774,30 @@ describe('useTextBuffer', () => {
       expect(getBufferState(result).text).toBe('');
     });
 
+    it('should handle Ctrl+Backspace as deleteWordLeft', () => {
+      const { result } = renderHook(() =>
+        useTextBuffer({
+          initialText: 'hello world',
+          viewport,
+          isValidPath: () => false,
+        }),
+      );
+      act(() => result.current.move('end'));
+      act(() => result.current.move('down'));
+      act(() => result.current.move('end'));
+      act(() =>
+        result.current.handleInput({
+          name: 'backspace',
+          ctrl: true,
+          meta: false,
+          shift: false,
+          sequence: '\x7f',
+        }),
+      );
+      expect(getBufferState(result).text).toBe('hello ');
+      expect(getBufferState(result).cursor).toEqual([0, 6]);
+    });
+
     it('should handle multiple delete characters in one input', () => {
       const { result } = renderHook(() =>
         useTextBuffer({

--- a/packages/cli/src/ui/components/shared/text-buffer.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer.ts
@@ -1186,8 +1186,9 @@ export function useTextBuffer({
       else if (key.name === 'end') move('end');
       else if (key.ctrl && key.name === 'e') move('end');
       else if (key.ctrl && key.name === 'w') deleteWordLeft();
+      else if (key.ctrl && key.name === 'backspace') deleteWordLeft();
       else if (
-        (key.meta || key.ctrl) &&
+        key.meta &&
         (key.name === 'backspace' || input === '\x7f')
       )
         deleteWordLeft();


### PR DESCRIPTION
## Summary
- bind Ctrl+Backspace to deleteWordLeft
- test Ctrl+Backspace word deletion

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6868691e11fc8331951059a12a838c54