### PR TITLE
Improve sandboxing docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,7 +116,7 @@ This command typically compiles TypeScript to JavaScript, bundles assets, and pr
 
 ### Enabling Sandboxing
 
-Container-based [sandboxing](#sandboxing) is highly recommended and requires, at a minimum, setting `GEMINI_SANDBOX=true` in your `~/.env` and ensuring a container engine (e.g. `docker` or `podman`) is available. See [Sandboxing](#sandboxing) for details.
+Container-based [sandboxing](#sandboxing) is highly recommended. Install **Docker** or **Podman** and set `GEMINI_SANDBOX=true` in your `~/.env` to enable it. See [docs/sandbox.md](docs/sandbox.md) for full setup instructions.
 
 To build both the `gemini` CLI utility and the sandbox container, run `build:all` from the root directory:
 
@@ -270,19 +270,32 @@ To debug the CLI's React-based UI, you can use React DevTools. Ink, the library 
 
 ## Sandboxing
 
-### MacOS Seatbelt
+Sandboxing runs the Gemini CLI in a restricted environment so that AI-generated
+commands cannot harm your host machine. We recommend enabling it whenever you
+work with unfamiliar prompts or code. At a minimum you need **Node 18+** and,
+for container-based sandboxing, an installation of **Docker** or **Podman**.
+macOS users can rely on the built-in Seatbelt utility.
 
-On MacOS, `gemini` uses Seatbelt (`sandbox-exec`) under a `permissive-open` profile (see `packages/cli/src/utils/sandbox-macos-permissive-open.sb`) that restricts writes to the project folder but otherwise allows all other operations and outbound network traffic ("open") by default. You can switch to a `restrictive-closed` profile (see `packages/cli/src/utils/sandbox-macos-restrictive-closed.sb`) that declines all operations and outbound network traffic ("closed") by default by setting `SEATBELT_PROFILE=restrictive-closed` in your environment or `.env` file. Available built-in profiles are `{permissive,restrictive}-{open,closed,proxied}` (see below for proxied networking). You can also switch to a custom profile `SEATBELT_PROFILE=<profile>` if you also create a file `.gemini/sandbox-macos-<profile>.sb` under your project settings directory `.gemini`.
+Gemini supports two sandboxing mechanisms:
+
+- **macOS Seatbelt** – a lightweight sandbox using Apple's `sandbox-exec`.
+- **Container-based** – a Docker or Podman container providing full isolation on any platform.
+
+See [docs/sandbox.md](docs/sandbox.md) for detailed instructions and troubleshooting.
+
+### macOS Seatbelt
+
+On macOS, `gemini` uses Seatbelt (`sandbox-exec`) under a `permissive-open` profile (see `packages/cli/src/utils/sandbox-macos-permissive-open.sb`) that restricts writes to the project folder but otherwise allows all other operations and outbound network traffic ("open") by default. You can switch to a `restrictive-closed` profile (see `packages/cli/src/utils/sandbox-macos-restrictive-closed.sb`) that declines all operations and outbound network traffic ("closed") by default by setting `SEATBELT_PROFILE=restrictive-closed` in your environment or `.env` file. Available built-in profiles are `{permissive,restrictive}-{open,closed,proxied}` (see below for proxied networking). You can also switch to a custom profile `SEATBELT_PROFILE=<profile>` if you also create a file `.gemini/sandbox-macos-<profile>.sb` under your project settings directory `.gemini`.
 
 ### Container-based Sandboxing (All Platforms)
 
-For stronger container-based sandboxing on MacOS or other platforms, you can set `GEMINI_SANDBOX=true|docker|podman|<command>` in your environment or `.env` file. The specified command (or if `true` then either `docker` or `podman`) must be installed on the host machine. Once enabled, `npm run build:all` will build a minimal container ("sandbox") image and `npm start` will launch inside a fresh instance of that container. The first build can take 20-30s (mostly due to downloading of the base image) but after that both build and start overhead should be minimal. Default builds (`npm run build`) will not rebuild the sandbox.
+For stronger container-based sandboxing on macOS or other platforms, you can set `GEMINI_SANDBOX=true|docker|podman|<command>` in your environment or `.env` file. The specified command (or if `true` then either `docker` or `podman`) must be installed on the host machine. Once enabled, `npm run build:all` will build a minimal container ("sandbox") image and `npm start` will launch inside a fresh instance of that container. The first build can take 20-30s (mostly due to downloading of the base image) but after that both build and start overhead should be minimal. Default builds (`npm run build`) will not rebuild the sandbox.
 
 Container-based sandboxing mounts the project directory (and system temp directory) with read-write access and is started/stopped/removed automatically as you start/stop Gemini CLI. Files created within the sandbox should be automatically mapped to your user/group on host machine. You can easily specify additional mounts, ports, or environment variables by setting `SANDBOX_{MOUNTS,PORTS,ENV}` as needed. You can also fully customize the sandbox for your projects by creating the files `.gemini/sandbox.Dockerfile` and/or `.gemini/sandbox.bashrc` under your project settings directory (`.gemini`) and running `gemini` with `BUILD_SANDBOX=1` to trigger building of your custom sandbox.
 
 #### Proxied Networking
 
-All sandboxing methods, including MacOS Seatbelt using `*-proxied` profiles, support restricting outbound network traffic through a custom proxy server that can be specified as `GEMINI_SANDBOX_PROXY_COMMAND=<command>`, where `<command>` must start a proxy server that listens on `:::8877` for relevant requests. See `scripts/example-proxy.js` for a minimal proxy that only allows `HTTPS` connections to `example.com:443` (e.g. `curl https://example.com`) and declines all other requests. The proxy is started and stopped automatically alongside the sandbox.
+All sandboxing methods, including macOS Seatbelt using `*-proxied` profiles, support restricting outbound network traffic through a custom proxy server that can be specified as `GEMINI_SANDBOX_PROXY_COMMAND=<command>`, where `<command>` must start a proxy server that listens on `:::8877` for relevant requests. See `scripts/example-proxy.js` for a minimal proxy that only allows `HTTPS` connections to `example.com:443` (e.g. `curl https://example.com`) and declines all other requests. The proxy is started and stopped automatically alongside the sandbox.
 
 ## Manual Publish
 

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -2,9 +2,20 @@
 
 This document provides a guide to sandboxing in the Gemini CLI, including prerequisites, quickstart, and configuration.
 
+Gemini CLI supports two approaches to sandboxing:
+
+- **macOS Seatbelt** – uses Apple's `sandbox-exec` utility and comes preinstalled on macOS.
+- **Container-based** – runs the CLI inside a Docker or Podman container for full process isolation on any platform.
+
+Container-based sandboxing generally offers stronger isolation and is recommended for everyday use.
+
 ## Prerequisites
 
-Before using sandboxing, you need to install and set up the Gemini CLI:
+Before using sandboxing, ensure the following are installed:
+
+- **Node 18+**
+- **Gemini CLI**
+- **Docker or Podman** (required for container-based sandboxing; Seatbelt is built into macOS)
 
 ```bash
 # install gemini-cli with npm
@@ -44,6 +55,9 @@ Cross-platform sandboxing with complete process isolation.
 ## Quickstart
 
 ```bash
+# Build the sandbox container (required once when using Docker or Podman)
+npm run build:all
+
 # Enable sandboxing with command flag
 gemini -s -p "analyze the code structure"
 


### PR DESCRIPTION
## Summary
- explain sandboxing and link to detailed docs
- refine macOS Seatbelt vs container sandbox information
- add prerequisites and quickstart steps

## Testing
- `npm run preflight`

------
https://chatgpt.com/codex/tasks/task_e_68687e27cb488331bc05b367752b9d5c