### PR TITLE
Add GOOGLE_CLOUD_PROJECT_ID fallback

### DIFF
--- a/docs/cli/authentication.md
+++ b/docs/cli/authentication.md
@@ -6,7 +6,7 @@ The Gemini CLI requires you to authenticate with Google's AI services. On initia
     - Use this option to log in with your google account.
     - During initial startup, Gemini CLI will direct you to a webpage for authentication. Once authenticated, your credentials will be cached locally so the web login can be skipped on subsequent runs.
     - Note that the web login must be done in a browser that can communicate with the machine Gemini CLI is being run from. (Specifically, the browser will be redirected to a localhost url that Gemini CLI will be listening on).
-    - <a id="workspace-gca">Users may have to specify a GOOGLE_CLOUD_PROJECT if:</a>
+    - <a id="workspace-gca">Users may have to specify a `GOOGLE_CLOUD_PROJECT` (or `GOOGLE_CLOUD_PROJECT_ID`) if:</a>
       1. You have a Google Workspace account. Google Workspace is a paid service for businesses and organizations that provides a suite of productivity tools, including a custom email domain (e.g. your-name@your-company.com), enhanced security features, and administrative controls. These accounts are often managed by an employer or school.
       1. You have received a free Code Assist license through the [Google Developer Program](https://developers.google.com/program/plans-and-pricing) (including qualified Google Developer Experts)
       1. You have been assigned a license to a current Gemini Code Assist standard or enterprise subscription.
@@ -14,7 +14,7 @@ The Gemini CLI requires you to authenticate with Google's AI services. On initia
       1. You are a Google account holder under the age of 18
       - If you fall into one of these categories, you must first configure a Google Cloud Project Id to use, [enable the Gemini for Cloud API](https://cloud.google.com/gemini/docs/discover/set-up-gemini#enable-api) and [configure access permissions](https://cloud.google.com/gemini/docs/discover/set-up-gemini#grant-iam).
 
-      You can temporarily set the environment variable in your current shell session using the following command:
+      You can temporarily set the environment variable in your current shell session using the following command (or set `GOOGLE_CLOUD_PROJECT_ID` if you prefer):
 
       ```bash
       export GOOGLE_CLOUD_PROJECT="YOUR_PROJECT_ID"
@@ -47,7 +47,7 @@ The Gemini CLI requires you to authenticate with Google's AI services. On initia
         gcloud auth application-default login
         ```
         For more information, see [Set up Application Default Credentials for Google Cloud](https://cloud.google.com/docs/authentication/provide-credentials-adc).
-      - Set the `GOOGLE_CLOUD_PROJECT`, `GOOGLE_CLOUD_LOCATION`, and `GOOGLE_GENAI_USE_VERTEXAI` environment variables. In the following methods, replace `YOUR_PROJECT_ID` and `YOUR_PROJECT_LOCATION` with the relevant values for your project:
+      - Set the `GOOGLE_CLOUD_PROJECT`, `GOOGLE_CLOUD_LOCATION`, and `GOOGLE_GENAI_USE_VERTEXAI` environment variables. If `GOOGLE_CLOUD_PROJECT` is not set, you can use `GOOGLE_CLOUD_PROJECT_ID`. In the following methods, replace `YOUR_PROJECT_ID` and `YOUR_PROJECT_LOCATION` with the relevant values for your project:
         - You can temporarily set these environment variables in your current shell session using the following commands:
           ```bash
           export GOOGLE_CLOUD_PROJECT="YOUR_PROJECT_ID"
@@ -96,7 +96,7 @@ Gemini CLI automatically loads environment variables from the **first** `.env` f
 
 ```bash
 mkdir -p .gemini
-echo 'GOOGLE_CLOUD_PROJECT="your-project-id"' >> .gemini/.env
+echo 'GOOGLE_CLOUD_PROJECT="your-project-id"' >> .gemini/.env  # or GOOGLE_CLOUD_PROJECT_ID
 ```
 
 **User-wide settings** (available in every directory):
@@ -104,7 +104,7 @@ echo 'GOOGLE_CLOUD_PROJECT="your-project-id"' >> .gemini/.env
 ```bash
 mkdir -p ~/.gemini
 cat >> ~/.gemini/.env <<'EOF'
-GOOGLE_CLOUD_PROJECT="your-project-id"
+GOOGLE_CLOUD_PROJECT="your-project-id" # or GOOGLE_CLOUD_PROJECT_ID
 GEMINI_API_KEY="your-gemini-api-key"
 EOF
 ```

--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -249,6 +249,9 @@ The CLI automatically loads environment variables from an `.env` file. The loadi
   - Required for using Code Assist or Vertex AI.
   - If using Vertex AI, ensure you have the necessary permissions and set the `GOOGLE_GENAI_USE_VERTEXAI=true` environment variable.
   - Example: `export GOOGLE_CLOUD_PROJECT="YOUR_PROJECT_ID"`.
+  - If this variable is not defined, the CLI will also read `GOOGLE_CLOUD_PROJECT_ID`.
+- **`GOOGLE_CLOUD_PROJECT_ID`**:
+  - Alternate variable for specifying your Google Cloud Project ID. Used when `GOOGLE_CLOUD_PROJECT` is undefined.
 - **`GOOGLE_APPLICATION_CREDENTIALS`** (string):
   - **Description:** The path to your Google Application Credentials JSON file.
   - **Example:** `export GOOGLE_APPLICATION_CREDENTIALS="/path/to/your/credentials.json"`

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -92,7 +92,8 @@ Use the `npm run telemetry -- --target=gcp` command to automate setting up a loc
 
 1.  **Prerequisites**:
     - Have a Google Cloud project ID.
-    - Export the `GOOGLE_CLOUD_PROJECT` environment variable to make it available to the OTEL collector.
+    - Export the `GOOGLE_CLOUD_PROJECT` environment variable to make it available to the OTEL collector. If
+      this variable is not set, `GOOGLE_CLOUD_PROJECT_ID` will be used as a fallback.
       ```bash
       export OTLP_GOOGLE_CLOUD_PROJECT="your-project-id"
       ```

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -8,8 +8,9 @@ This guide provides solutions to common issues and debugging tips.
   - Users with Google Workspace accounts, or users with Google Cloud accounts
     associated with their Gmail accounts may not be able to activate the free
     tier of the Google Code Assist plan.
-  - For Google Cloud accounts, you can work around this by setting
-    `GOOGLE_CLOUD_PROJECT` to your project ID.
+  - For Google Cloud accounts, you can work around this by setting the
+    `GOOGLE_CLOUD_PROJECT` environment variable to your project ID. If that
+    variable is not set, Gemini CLI also checks `GOOGLE_CLOUD_PROJECT_ID`.
   - You can also grab an API key from [AI Studio](https://aistudio.google.com/app/apikey), which also includes a
     separate free tier.
 

--- a/packages/cli/src/config/auth.test.ts
+++ b/packages/cli/src/config/auth.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { validateAuthMethod } from './auth.js';
+import { AuthType } from '@google/gemini-cli-core';
+
+// Helper to clear env after each test
+const ORIGINAL_ENV = { ...process.env };
+
+beforeEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+});
+
+describe('validateAuthMethod', () => {
+  it('accepts Vertex AI when GOOGLE_CLOUD_PROJECT is set', () => {
+    process.env.GOOGLE_CLOUD_PROJECT = 'proj';
+    process.env.GOOGLE_CLOUD_LOCATION = 'loc';
+    const res = validateAuthMethod(AuthType.USE_VERTEX_AI);
+    expect(res).toBeNull();
+  });
+
+  it('accepts Vertex AI when GOOGLE_CLOUD_PROJECT_ID is used as fallback', () => {
+    delete process.env.GOOGLE_CLOUD_PROJECT;
+    process.env.GOOGLE_CLOUD_PROJECT_ID = 'proj-id';
+    process.env.GOOGLE_CLOUD_LOCATION = 'loc';
+    const res = validateAuthMethod(AuthType.USE_VERTEX_AI);
+    expect(res).toBeNull();
+  });
+});

--- a/packages/cli/src/config/auth.ts
+++ b/packages/cli/src/config/auth.ts
@@ -22,7 +22,9 @@ export const validateAuthMethod = (authMethod: string): string | null => {
 
   if (authMethod === AuthType.USE_VERTEX_AI) {
     const hasVertexProjectLocationConfig =
-      !!process.env.GOOGLE_CLOUD_PROJECT && !!process.env.GOOGLE_CLOUD_LOCATION;
+      (!!process.env.GOOGLE_CLOUD_PROJECT ||
+        !!process.env.GOOGLE_CLOUD_PROJECT_ID) &&
+      !!process.env.GOOGLE_CLOUD_LOCATION;
     const hasGoogleApiKey = !!process.env.GOOGLE_API_KEY;
     if (!hasVertexProjectLocationConfig && !hasGoogleApiKey) {
       return (

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.test.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.test.ts
@@ -421,6 +421,58 @@ describe('useSlashCommandProcessor', () => {
       );
     });
 
+    it('should read gcp project from GOOGLE_CLOUD_PROJECT_ID when GOOGLE_CLOUD_PROJECT is not set', async () => {
+      // Arrange
+      mockGetCliVersionFn.mockResolvedValue('test-version');
+      process.env.SANDBOX = 'gemini-sandbox';
+      delete process.env.GOOGLE_CLOUD_PROJECT;
+      process.env.GOOGLE_CLOUD_PROJECT_ID = 'fallback-project';
+      vi.mocked(mockConfig.getModel).mockReturnValue('test-model-from-config');
+
+      const settings = {
+        merged: {
+          selectedAuthType: 'test-auth-type',
+          contextFileName: 'GEMINI.md',
+        },
+      } as LoadedSettings;
+
+      const { result } = renderHook(() =>
+        useSlashCommandProcessor(
+          mockConfig,
+          settings,
+          [],
+          mockAddItem,
+          mockClearItems,
+          mockLoadHistory,
+          mockRefreshStatic,
+          mockSetShowHelp,
+          mockOnDebugMessage,
+          mockOpenThemeDialog,
+          mockOpenAuthDialog,
+          mockOpenEditorDialog,
+          mockPerformMemoryRefresh,
+          mockCorgiMode,
+          false,
+          mockSetQuittingMessages,
+        ),
+      );
+
+      // Act
+      await act(async () => {
+        await result.current.handleSlashCommand('/about');
+      });
+
+      // Assert
+      expect(mockAddItem).toHaveBeenCalledTimes(2); // user message + about message
+      expect(mockAddItem).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          gcpProject: 'fallback-project',
+        }),
+        expect.any(Number),
+      );
+    });
+
     it('should show sandbox-exec profile when applicable', async () => {
       // Arrange
       mockGetCliVersionFn.mockResolvedValue('test-version');

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.ts
@@ -621,7 +621,10 @@ export const useSlashCommandProcessor = (
           const modelVersion = config?.getModel() || 'Unknown';
           const cliVersion = await getCliVersion();
           const selectedAuthType = settings.merged.selectedAuthType || '';
-          const gcpProject = process.env.GOOGLE_CLOUD_PROJECT || '';
+          const gcpProject =
+            process.env.GOOGLE_CLOUD_PROJECT ||
+            process.env.GOOGLE_CLOUD_PROJECT_ID ||
+            '';
           addMessage({
             type: MessageType.ABOUT,
             timestamp: new Date(),

--- a/packages/cli/src/utils/sandbox.ts
+++ b/packages/cli/src/utils/sandbox.ts
@@ -526,11 +526,10 @@ export async function start_sandbox(
   }
 
   // copy GOOGLE_CLOUD_PROJECT
-  if (process.env.GOOGLE_CLOUD_PROJECT) {
-    args.push(
-      '--env',
-      `GOOGLE_CLOUD_PROJECT=${process.env.GOOGLE_CLOUD_PROJECT}`,
-    );
+  const gcpProject =
+    process.env.GOOGLE_CLOUD_PROJECT || process.env.GOOGLE_CLOUD_PROJECT_ID;
+  if (gcpProject) {
+    args.push('--env', `GOOGLE_CLOUD_PROJECT=${gcpProject}`);
   }
 
   // copy GOOGLE_CLOUD_LOCATION

--- a/packages/core/src/code_assist/setup.ts
+++ b/packages/core/src/code_assist/setup.ts
@@ -28,7 +28,8 @@ export class ProjectIdRequiredError extends Error {
  * @returns the user's actual project id
  */
 export async function setupUser(client: OAuth2Client): Promise<string> {
-  let projectId = process.env.GOOGLE_CLOUD_PROJECT;
+  let projectId =
+    process.env.GOOGLE_CLOUD_PROJECT || process.env.GOOGLE_CLOUD_PROJECT_ID;
   const caServer = new CodeAssistServer(client, projectId);
 
   const clientMetadata: ClientMetadata = {

--- a/packages/core/src/core/contentGenerator.ts
+++ b/packages/core/src/core/contentGenerator.ts
@@ -54,7 +54,8 @@ export async function createContentGeneratorConfig(
 ): Promise<ContentGeneratorConfig> {
   const geminiApiKey = process.env.GEMINI_API_KEY;
   const googleApiKey = process.env.GOOGLE_API_KEY;
-  const googleCloudProject = process.env.GOOGLE_CLOUD_PROJECT;
+  const googleCloudProject =
+    process.env.GOOGLE_CLOUD_PROJECT || process.env.GOOGLE_CLOUD_PROJECT_ID;
   const googleCloudLocation = process.env.GOOGLE_CLOUD_LOCATION;
 
   // Use runtime model from config if available, otherwise fallback to parameter or default


### PR DESCRIPTION
## Summary
- allow GOOGLE_CLOUD_PROJECT_ID as a fallback for GOOGLE_CLOUD_PROJECT
- propagate the new env var through sandbox and slash command logic
- document the fallback throughout docs
- add tests for the new behavior

## Testing
- `npm run build --workspaces`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68687e2696788331a7cf7c87ad35466f