### PR TITLE
Add Mononoke theme

### DIFF
--- a/docs/cli/themes.md
+++ b/docs/cli/themes.md
@@ -13,6 +13,7 @@ Gemini CLI comes with a selection of pre-defined themes, which you can list usin
   - `Default`
   - `Dracula`
   - `GitHub`
+  - `Mononoke`
 - **Light Themes:**
   - `ANSI Light`
   - `Ayu Light`
@@ -57,6 +58,10 @@ Selected themes are saved in Gemini CLI's [configuration](./configuration.md) so
 ### GitHub
 
 <img src="../assets/theme-github.png" alt="GitHub theme" width="600">
+
+### Mononoke
+
+<img src="../assets/theme-mononoke.png" alt="Mononoke theme" width="600">
 
 ## Light Themes
 

--- a/packages/cli/src/ui/themes/__tests__/mononoke.test.ts
+++ b/packages/cli/src/ui/themes/__tests__/mononoke.test.ts
@@ -1,0 +1,28 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { themeManager } from '../theme-manager.js';
+
+// Ensure default theme is reset before each test
+beforeEach(() => {
+  themeManager.setActiveTheme(undefined);
+});
+
+describe('Mononoke theme registration', () => {
+  it('should be listed among available themes', () => {
+    const themeNames = themeManager
+      .getAvailableThemes()
+      .map((t) => t.name);
+    expect(themeNames).toContain('Mononoke');
+  });
+
+  it('can be set as the active theme', () => {
+    const result = themeManager.setActiveTheme('Mononoke');
+    expect(result).toBe(true);
+    expect(themeManager.getActiveTheme().name).toBe('Mononoke');
+  });
+});

--- a/packages/cli/src/ui/themes/mononoke.ts
+++ b/packages/cli/src/ui/themes/mononoke.ts
@@ -1,0 +1,120 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { type ColorsTheme, Theme } from './theme.js';
+
+const mononokeColors: ColorsTheme = {
+  type: 'dark',
+  Background: '#1b1b1b',
+  Foreground: '#c8d3f5',
+  LightBlue: '#7dcfff',
+  AccentBlue: '#82aaff',
+  AccentPurple: '#c792ea',
+  AccentCyan: '#89ddff',
+  AccentGreen: '#c3e88d',
+  AccentYellow: '#ffcb6b',
+  AccentRed: '#f07178',
+  Comment: '#545c7e',
+  Gray: '#717cb4',
+  GradientColors: ['#82aaff', '#c792ea'],
+};
+
+export const Mononoke: Theme = new Theme(
+  'Mononoke',
+  'dark',
+  {
+    hljs: {
+      display: 'block',
+      overflowX: 'auto',
+      padding: '0.5em',
+      background: mononokeColors.Background,
+      color: mononokeColors.Foreground,
+    },
+    'hljs-keyword': {
+      color: mononokeColors.AccentBlue,
+      fontWeight: 'bold',
+    },
+    'hljs-selector-tag': {
+      color: mononokeColors.AccentBlue,
+      fontWeight: 'bold',
+    },
+    'hljs-literal': {
+      color: mononokeColors.AccentBlue,
+      fontWeight: 'bold',
+    },
+    'hljs-section': {
+      color: mononokeColors.AccentBlue,
+      fontWeight: 'bold',
+    },
+    'hljs-link': {
+      color: mononokeColors.AccentBlue,
+    },
+    'hljs-function .hljs-keyword': {
+      color: mononokeColors.AccentPurple,
+    },
+    'hljs-subst': {
+      color: mononokeColors.Foreground,
+    },
+    'hljs-string': {
+      color: mononokeColors.AccentYellow,
+    },
+    'hljs-title': {
+      color: mononokeColors.AccentYellow,
+      fontWeight: 'bold',
+    },
+    'hljs-name': {
+      color: mononokeColors.AccentYellow,
+      fontWeight: 'bold',
+    },
+    'hljs-type': {
+      color: mononokeColors.AccentYellow,
+      fontWeight: 'bold',
+    },
+    'hljs-attribute': {
+      color: mononokeColors.AccentYellow,
+    },
+    'hljs-symbol': {
+      color: mononokeColors.AccentYellow,
+    },
+    'hljs-bullet': {
+      color: mononokeColors.AccentYellow,
+    },
+    'hljs-addition': {
+      color: mononokeColors.AccentGreen,
+    },
+    'hljs-variable': {
+      color: mononokeColors.AccentYellow,
+    },
+    'hljs-template-tag': {
+      color: mononokeColors.AccentYellow,
+    },
+    'hljs-template-variable': {
+      color: mononokeColors.AccentYellow,
+    },
+    'hljs-comment': {
+      color: mononokeColors.Comment,
+    },
+    'hljs-quote': {
+      color: mononokeColors.Comment,
+    },
+    'hljs-deletion': {
+      color: mononokeColors.AccentRed,
+    },
+    'hljs-meta': {
+      color: mononokeColors.Comment,
+    },
+    'hljs-doctag': {
+      fontWeight: 'bold',
+    },
+    'hljs-strong': {
+      fontWeight: 'bold',
+    },
+    'hljs-emphasis': {
+      fontStyle: 'italic',
+    },
+  },
+  mononokeColors,
+);

--- a/packages/cli/src/ui/themes/theme-manager.ts
+++ b/packages/cli/src/ui/themes/theme-manager.ts
@@ -15,6 +15,7 @@ import { DefaultLight } from './default-light.js';
 import { DefaultDark } from './default.js';
 import { ShadesOfPurple } from './shades-of-purple.js';
 import { XCode } from './xcode.js';
+import { Mononoke } from './mononoke.js';
 import { Theme, ThemeType } from './theme.js';
 import { ANSI } from './ansi.js';
 import { ANSILight } from './ansi-light.js';
@@ -41,6 +42,7 @@ class ThemeManager {
       DefaultLight,
       DefaultDark,
       GitHubDark,
+      Mononoke,
       GitHubLight,
       GoogleCode,
       ShadesOfPurple,


### PR DESCRIPTION
## Summary
- add new Mononoke dark theme implementation
- register Mononoke in the theme manager
- document Mononoke in the themes guide
- test theme registration

## Testing
- `npm test --workspace packages/cli`
- `npm test --workspaces`

------
https://chatgpt.com/codex/tasks/task_e_68687e245f1483318a96ae47bd6757df