### PR TITLE
Clarify auto-apply edits indicator

### DIFF
--- a/packages/cli/src/ui/components/AutoAcceptIndicator.tsx
+++ b/packages/cli/src/ui/components/AutoAcceptIndicator.tsx
@@ -23,8 +23,8 @@ export const AutoAcceptIndicator: React.FC<AutoAcceptIndicatorProps> = ({
   switch (approvalMode) {
     case ApprovalMode.AUTO_EDIT:
       textColor = Colors.AccentGreen;
-      textContent = 'accepting edits';
-      subText = ' (shift + tab to toggle)';
+      textContent = 'mode: auto-apply edits';
+      subText = ' (shift+tab to disable)';
       break;
     case ApprovalMode.YOLO:
       textColor = Colors.AccentRed;

--- a/packages/cli/src/ui/components/Help.tsx
+++ b/packages/cli/src/ui/components/Help.tsx
@@ -119,7 +119,7 @@ export const Help: React.FC<Help> = ({ commands }) => (
       <Text bold color={Colors.AccentPurple}>
         Shift+Tab
       </Text>{' '}
-      - Toggle auto-accepting edits
+      - Toggle auto-apply edits mode
     </Text>
     <Text color={Colors.Foreground}>
       <Text bold color={Colors.AccentPurple}>


### PR DESCRIPTION
## Summary
- clarify wording for auto apply edits indicator
- update the Help panel text accordingly

## Testing
- `npm test --workspace packages/cli`


------
https://chatgpt.com/codex/tasks/task_e_68687e22d6d88331ba315b09ad4d36bf