### PR TITLE
Fix shell color streaming

### DIFF
--- a/packages/cli/src/ui/hooks/shellCommandProcessor.test.ts
+++ b/packages/cli/src/ui/hooks/shellCommandProcessor.test.ts
@@ -176,4 +176,42 @@ describe('useShellCommandProcessor', () => {
       text: 'Command exited with code 127.\ncommand not found',
     });
   });
+
+  it('should pass through ANSI color codes while streaming', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+
+    const { result } = renderProcessorHook();
+    const abortController = new AbortController();
+
+    act(() => {
+      result.current.handleShellCommand('echo', abortController.signal);
+    });
+
+    const execPromise = onExecMock.mock.calls[0][0];
+
+    const colored = '\u001b[31mred\u001b[0m';
+    act(() => {
+      vi.setSystemTime(1100);
+      spawnEmitter.stdout.emit('data', Buffer.from(colored));
+    });
+
+    act(() => {
+      spawnEmitter.emit('exit', 0, null);
+    });
+
+    await act(async () => {
+      await execPromise;
+    });
+
+    expect(setPendingHistoryItemMock).toHaveBeenCalledWith({
+      type: 'info',
+      text: colored,
+    });
+
+    expect(addItemToHistoryMock.mock.calls[1][0]).toEqual({
+      type: 'info',
+      text: 'red',
+    });
+  });
 });

--- a/packages/cli/src/ui/hooks/shellCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/shellCommandProcessor.ts
@@ -71,6 +71,8 @@ function executeShellCommand(
 
     let stdout = '';
     let stderr = '';
+    let stdoutRaw = '';
+    let stderrRaw = '';
     const outputChunks: Buffer[] = [];
     let error: Error | null = null;
     let exited = false;
@@ -99,14 +101,16 @@ function executeShellCommand(
           ? stdoutDecoder.write(data)
           : stderrDecoder.write(data);
       if (stream === 'stdout') {
+        stdoutRaw += decodedChunk;
         stdout += stripAnsi(decodedChunk);
       } else {
+        stderrRaw += decodedChunk;
         stderr += stripAnsi(decodedChunk);
       }
 
       if (!exited && streamToUi) {
         // Send only the new chunk to avoid re-rendering the whole output.
-        const combinedOutput = stdout + (stderr ? `\n${stderr}` : '');
+        const combinedOutput = stdoutRaw + (stderrRaw ? `\n${stderrRaw}` : '');
         onOutputChunk(combinedOutput);
       } else if (!exited && !streamToUi) {
         // Send progress updates for the binary stream
@@ -155,8 +159,12 @@ function executeShellCommand(
       abortSignal.removeEventListener('abort', abortHandler);
 
       // Handle any final bytes lingering in the decoders
-      stdout += stdoutDecoder.end();
-      stderr += stderrDecoder.end();
+      const stdoutTail = stdoutDecoder.end();
+      const stderrTail = stderrDecoder.end();
+      stdoutRaw += stdoutTail;
+      stderrRaw += stderrTail;
+      stdout += stripAnsi(stdoutTail);
+      stderr += stripAnsi(stderrTail);
 
       const finalBuffer = Buffer.concat(outputChunks);
 


### PR DESCRIPTION
## Summary
- keep ANSI colors in streamed shell output
- test that shell streams pass through color codes

## Testing
- `npm run build:packages`
- `npm test -w packages/cli`

------
https://chatgpt.com/codex/tasks/task_e_68688e1c91e88331a58baf2d0b529ad1