### PR TITLE
Allow flash model override via env

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,11 @@ The Gemini API provides a free tier with [100 requests per day](https://ai.googl
 1. Generate a key from [Google AI Studio](https://aistudio.google.com/apikey).
 2. Set it as an environment variable in your terminal. Replace `YOUR_API_KEY` with your generated key.
 
-   ```bash
-   export GEMINI_API_KEY="YOUR_API_KEY"
-   ```
+ ```bash
+ export GEMINI_API_KEY="YOUR_API_KEY"
+ # Optional: override the default Flash fallback model
+ export GEMINI_FLASH_MODEL="gemini-2.5-flash"
+ ```
 
 3. (Optionally) Upgrade your Gemini API project to a paid plan on the API key page (will automatically unlock [Tier 1 rate limits](https://ai.google.dev/gemini-api/docs/rate-limits#tier-1))
 

--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -239,6 +239,10 @@ The CLI automatically loads environment variables from an `.env` file. The loadi
   - Specifies the default Gemini model to use.
   - Overrides the hardcoded default
   - Example: `export GEMINI_MODEL="gemini-2.5-flash"`
+- **`GEMINI_FLASH_MODEL`**:
+  - Specifies the fallback Flash model.
+  - Overrides the hardcoded default used when the Pro model is unavailable.
+  - Example: `export GEMINI_FLASH_MODEL="gemini-2.5-flash"`
 - **`GOOGLE_API_KEY`**:
   - Your Google Cloud API key.
   - Required for using Vertex AI in express mode.

--- a/packages/cli/src/utils/sandbox.ts
+++ b/packages/cli/src/utils/sandbox.ts
@@ -546,6 +546,11 @@ export async function start_sandbox(
     args.push('--env', `GEMINI_MODEL=${process.env.GEMINI_MODEL}`);
   }
 
+  // copy GEMINI_FLASH_MODEL
+  if (process.env.GEMINI_FLASH_MODEL) {
+    args.push('--env', `GEMINI_FLASH_MODEL=${process.env.GEMINI_FLASH_MODEL}`);
+  }
+
   // copy TERM and COLORTERM to try to maintain terminal setup
   if (process.env.TERM) {
     args.push('--env', `TERM=${process.env.TERM}`);

--- a/packages/core/src/config/models.test.ts
+++ b/packages/core/src/config/models.test.ts
@@ -1,0 +1,35 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+describe('DEFAULT_GEMINI_FLASH_MODEL', () => {
+  const originalEnv = process.env.GEMINI_FLASH_MODEL;
+
+  afterEach(() => {
+    vi.resetModules();
+    if (originalEnv === undefined) {
+      delete process.env.GEMINI_FLASH_MODEL;
+    } else {
+      process.env.GEMINI_FLASH_MODEL = originalEnv;
+    }
+  });
+
+  it('uses GEMINI_FLASH_MODEL env var when set', async () => {
+    process.env.GEMINI_FLASH_MODEL = 'custom-flash';
+    vi.resetModules();
+    const { DEFAULT_GEMINI_FLASH_MODEL } = await import('./models.js');
+    expect(DEFAULT_GEMINI_FLASH_MODEL).toBe('custom-flash');
+  });
+
+  it('falls back to default when env var is not set', async () => {
+    delete process.env.GEMINI_FLASH_MODEL;
+    vi.resetModules();
+    const { DEFAULT_GEMINI_FLASH_MODEL } = await import('./models.js');
+    expect(DEFAULT_GEMINI_FLASH_MODEL).toBe('gemini-2.5-flash');
+  });
+});
+

--- a/packages/core/src/config/models.ts
+++ b/packages/core/src/config/models.ts
@@ -5,5 +5,6 @@
  */
 
 export const DEFAULT_GEMINI_MODEL = 'gemini-2.5-pro';
-export const DEFAULT_GEMINI_FLASH_MODEL = 'gemini-2.5-flash';
+export const DEFAULT_GEMINI_FLASH_MODEL =
+  process.env.GEMINI_FLASH_MODEL || 'gemini-2.5-flash';
 export const DEFAULT_GEMINI_EMBEDDING_MODEL = 'gemini-embedding-001';


### PR DESCRIPTION
## Summary
- support `GEMINI_FLASH_MODEL` environment variable
- document how to override the flash model
- forward `GEMINI_FLASH_MODEL` into sandbox
- add unit test for env var override

## Testing
- `npm test -w packages/core`

------
https://chatgpt.com/codex/tasks/task_e_68688b85487483319a0e68264d1cbaa4