### PR TITLE
Add full path display with optional shortening

### DIFF
--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -53,6 +53,7 @@ interface CliArgs {
   telemetryTarget: string | undefined;
   telemetryOtlpEndpoint: string | undefined;
   telemetryLogPrompts: boolean | undefined;
+  'path-shortening': boolean | undefined;
 }
 
 async function parseArguments(): Promise<CliArgs> {
@@ -127,6 +128,11 @@ async function parseArguments(): Promise<CliArgs> {
       type: 'boolean',
       description: 'Enables checkpointing of file edits',
       default: false,
+    })
+    .option('path-shortening', {
+      type: 'boolean',
+      description: 'Shorten displayed file paths. Use --no-path-shortening to show full paths.',
+      default: true,
     })
     .version(await getCliVersion()) // This will enable the --version flag based on package.json
     .alias('v', 'version')
@@ -245,6 +251,7 @@ export async function loadCliConfig(
     fileDiscoveryService: fileService,
     bugCommand: settings.bugCommand,
     model: argv.model!,
+    shortenPaths: argv['path-shortening'],
     extensionContextFilePaths,
   });
 }

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -129,6 +129,7 @@ export interface ConfigParameters {
   fileDiscoveryService?: FileDiscoveryService;
   bugCommand?: BugCommandSettings;
   model: string;
+  shortenPaths?: boolean;
   extensionContextFilePaths?: string[];
 }
 
@@ -168,6 +169,7 @@ export class Config {
   private readonly bugCommand: BugCommandSettings | undefined;
   private readonly model: string;
   private readonly extensionContextFilePaths: string[];
+  private readonly shortenPaths: boolean;
   private modelSwitchedDuringSession: boolean = false;
   flashFallbackHandler?: FlashFallbackHandler;
 
@@ -211,6 +213,7 @@ export class Config {
     this.bugCommand = params.bugCommand;
     this.model = params.model;
     this.extensionContextFilePaths = params.extensionContextFilePaths ?? [];
+    this.shortenPaths = params.shortenPaths ?? true;
 
     if (params.contextFileName) {
       setGeminiMdFilename(params.contextFileName);
@@ -424,6 +427,10 @@ export class Config {
 
   getWorkingDir(): string {
     return this.cwd;
+  }
+
+  getPathShorteningEnabled(): boolean {
+    return this.shortenPaths;
   }
 
   getBugCommand(): BugCommandSettings | undefined {

--- a/packages/core/src/tools/edit.test.ts
+++ b/packages/core/src/tools/edit.test.ts
@@ -75,6 +75,7 @@ describe('EditTool', () => {
       getGeminiMdFileCount: () => 0,
       setGeminiMdFileCount: vi.fn(),
       getToolRegistry: () => ({}) as any, // Minimal mock for ToolRegistry
+      getPathShorteningEnabled: () => true,
     } as unknown as Config;
 
     // Reset mocks before each test
@@ -255,7 +256,7 @@ describe('EditTool', () => {
       );
       expect(confirmation).toEqual(
         expect.objectContaining({
-          title: `Confirm Edit: ${testFile}`,
+          title: `Confirm Edit: ${testFile} (${path.join(rootDir, testFile)})`,
           fileName: testFile,
           fileDiff: expect.any(String),
         }),
@@ -306,7 +307,10 @@ describe('EditTool', () => {
       );
       expect(confirmation).toEqual(
         expect.objectContaining({
-          title: `Confirm Edit: ${newFileName}`,
+          title: `Confirm Edit: ${newFileName} (${path.join(
+            rootDir,
+            newFileName,
+          )})`,
           fileName: newFileName,
           fileDiff: expect.any(String),
         }),
@@ -358,7 +362,7 @@ describe('EditTool', () => {
       // expect(mockEnsureCorrectEdit).toHaveBeenCalledWith(originalContent, params, expect.anything()); // Keep this commented for now
       expect(confirmation).toEqual(
         expect.objectContaining({
-          title: `Confirm Edit: ${testFile}`,
+          title: `Confirm Edit: ${testFile} (${path.join(rootDir, testFile)})`,
           fileName: testFile,
         }),
       );
@@ -456,7 +460,9 @@ describe('EditTool', () => {
       expect(result.llmContent).toMatch(/Created new file/);
       expect(fs.existsSync(newFilePath)).toBe(true);
       expect(fs.readFileSync(newFilePath, 'utf8')).toBe(fileContent);
-      expect(result.returnDisplay).toBe(`Created ${newFileName}`);
+      expect(result.returnDisplay).toBe(
+        `Created ${newFileName} (${newFilePath})`,
+      );
     });
 
     it('should return error if old_string is not found in file', async () => {
@@ -618,9 +624,8 @@ describe('EditTool', () => {
         old_string: 'identical_string',
         new_string: 'identical_string',
       };
-      // shortenPath will be called internally, resulting in just the file name
       expect(tool.getDescription(params)).toBe(
-        `No file changes to ${testFileName}`,
+        `No file changes to ${testFileName} (${path.join(rootDir, testFileName)})`,
       );
     });
 
@@ -631,10 +636,11 @@ describe('EditTool', () => {
         old_string: 'this is the old string value',
         new_string: 'this is the new string value',
       };
-      // shortenPath will be called internally, resulting in just the file name
-      // The snippets are truncated at 30 chars + '...'
       expect(tool.getDescription(params)).toBe(
-        `${testFileName}: this is the old string value => this is the new string value`,
+        `${testFileName} (${path.join(
+          rootDir,
+          testFileName,
+        )}): this is the old string value => this is the new string value`,
       );
     });
 
@@ -645,7 +651,9 @@ describe('EditTool', () => {
         old_string: 'old',
         new_string: 'new',
       };
-      expect(tool.getDescription(params)).toBe(`${testFileName}: old => new`);
+      expect(tool.getDescription(params)).toBe(
+        `${testFileName} (${path.join(rootDir, testFileName)}): old => new`,
+      );
     });
 
     it('should truncate long strings in the description', () => {
@@ -658,7 +666,10 @@ describe('EditTool', () => {
           'this is a very long new string that will also be truncated',
       };
       expect(tool.getDescription(params)).toBe(
-        `${testFileName}: this is a very long old string... => this is a very long new string...`,
+        `${testFileName} (${path.join(
+          rootDir,
+          testFileName,
+        )}): this is a very long old string... => this is a very long new string...`,
       );
     });
   });

--- a/packages/core/src/tools/edit.ts
+++ b/packages/core/src/tools/edit.ts
@@ -16,7 +16,7 @@ import {
   ToolResultDisplay,
 } from './tools.js';
 import { SchemaValidator } from '../utils/schemaValidator.js';
-import { makeRelative, shortenPath } from '../utils/paths.js';
+import { makeRelative, shortenPath, formatDisplayPath } from '../utils/paths.js';
 import { isNodeError } from '../utils/errors.js';
 import { GeminiClient } from '../core/client.js';
 import { Config, ApprovalMode } from '../config/config.js';
@@ -331,9 +331,14 @@ Expectation for required parameters:
       'Proposed',
       DEFAULT_DIFF_OPTIONS,
     );
+    const relativePath = makeRelative(params.file_path, this.rootDirectory);
     const confirmationDetails: ToolEditConfirmationDetails = {
       type: 'edit',
-      title: `Confirm Edit: ${shortenPath(makeRelative(params.file_path, this.rootDirectory))}`,
+      title: `Confirm Edit: ${formatDisplayPath(
+        relativePath,
+        params.file_path,
+        this.config.getPathShorteningEnabled(),
+      )}`,
       fileName,
       fileDiff,
       onConfirm: async (outcome: ToolConfirmationOutcome) => {
@@ -350,8 +355,13 @@ Expectation for required parameters:
       return `Model did not provide valid parameters for edit tool`;
     }
     const relativePath = makeRelative(params.file_path, this.rootDirectory);
+    const displayPath = formatDisplayPath(
+      relativePath,
+      params.file_path,
+      this.config.getPathShorteningEnabled(),
+    );
     if (params.old_string === '') {
-      return `Create ${shortenPath(relativePath)}`;
+      return `Create ${displayPath}`;
     }
 
     const oldStringSnippet =
@@ -362,9 +372,9 @@ Expectation for required parameters:
       (params.new_string.length > 30 ? '...' : '');
 
     if (params.old_string === params.new_string) {
-      return `No file changes to ${shortenPath(relativePath)}`;
+      return `No file changes to ${displayPath}`;
     }
-    return `${shortenPath(relativePath)}: ${oldStringSnippet} => ${newStringSnippet}`;
+    return `${displayPath}: ${oldStringSnippet} => ${newStringSnippet}`;
   }
 
   /**
@@ -408,7 +418,12 @@ Expectation for required parameters:
 
       let displayResult: ToolResultDisplay;
       if (editData.isNewFile) {
-        displayResult = `Created ${shortenPath(makeRelative(params.file_path, this.rootDirectory))}`;
+        const relative = makeRelative(params.file_path, this.rootDirectory);
+        displayResult = `Created ${formatDisplayPath(
+          relative,
+          params.file_path,
+          this.config.getPathShorteningEnabled(),
+        )}`;
       } else {
         // Generate diff for display, even though core logic doesn't technically need it
         // The CLI wrapper will use this part of the ToolResult

--- a/packages/core/src/tools/ls.ts
+++ b/packages/core/src/tools/ls.ts
@@ -8,7 +8,7 @@ import fs from 'fs';
 import path from 'path';
 import { BaseTool, ToolResult } from './tools.js';
 import { SchemaValidator } from '../utils/schemaValidator.js';
-import { makeRelative, shortenPath } from '../utils/paths.js';
+import { makeRelative, formatDisplayPath } from '../utils/paths.js';
 import { Config } from '../config/config.js';
 
 /**
@@ -181,7 +181,11 @@ export class LSTool extends BaseTool<LSToolParams, ToolResult> {
    */
   getDescription(params: LSToolParams): string {
     const relativePath = makeRelative(params.path, this.rootDirectory);
-    return shortenPath(relativePath);
+    return formatDisplayPath(
+      relativePath,
+      params.path,
+      this.config.getPathShorteningEnabled(),
+    );
   }
 
   // Helper for consistent error formatting

--- a/packages/core/src/tools/write-file.test.ts
+++ b/packages/core/src/tools/write-file.test.ts
@@ -74,6 +74,7 @@ const mockConfigInternal = {
       registerTool: vi.fn(),
       discoverTools: vi.fn(),
     }) as unknown as ToolRegistry,
+  getPathShorteningEnabled: () => true,
 };
 const mockConfig = mockConfigInternal as unknown as Config;
 // --- END MOCKS ---
@@ -351,7 +352,7 @@ describe('WriteFileTool', () => {
       );
       expect(confirmation).toEqual(
         expect.objectContaining({
-          title: `Confirm Write: ${path.basename(filePath)}`,
+          title: `Confirm Write: ${path.basename(filePath)} (${filePath})`,
           fileName: 'confirm_new_file.txt',
           fileDiff: expect.stringContaining(correctedContent),
         }),
@@ -399,7 +400,7 @@ describe('WriteFileTool', () => {
       );
       expect(confirmation).toEqual(
         expect.objectContaining({
-          title: `Confirm Write: ${path.basename(filePath)}`,
+          title: `Confirm Write: ${path.basename(filePath)} (${filePath})`,
           fileName: 'confirm_existing_file.txt',
           fileDiff: expect.stringContaining(correctedProposedContent),
         }),

--- a/packages/core/src/tools/write-file.ts
+++ b/packages/core/src/tools/write-file.ts
@@ -17,7 +17,7 @@ import {
   ToolCallConfirmationDetails,
 } from './tools.js';
 import { SchemaValidator } from '../utils/schemaValidator.js';
-import { makeRelative, shortenPath } from '../utils/paths.js';
+import { makeRelative, formatDisplayPath } from '../utils/paths.js';
 import { getErrorMessage, isNodeError } from '../utils/errors.js';
 import {
   ensureCorrectEdit,
@@ -159,7 +159,12 @@ export class WriteFileTool
       params.file_path,
       this.config.getTargetDir(),
     );
-    return `Writing to ${shortenPath(relativePath)}`;
+    const displayPath = formatDisplayPath(
+      relativePath,
+      params.file_path,
+      this.config.getPathShorteningEnabled(),
+    );
+    return `Writing to ${displayPath}`;
   }
 
   /**
@@ -207,7 +212,11 @@ export class WriteFileTool
 
     const confirmationDetails: ToolEditConfirmationDetails = {
       type: 'edit',
-      title: `Confirm Write: ${shortenPath(relativePath)}`,
+      title: `Confirm Write: ${formatDisplayPath(
+        relativePath,
+        params.file_path,
+        this.config.getPathShorteningEnabled(),
+      )}`,
       fileName,
       fileDiff,
       onConfirm: async (outcome: ToolConfirmationOutcome) => {

--- a/packages/core/src/utils/paths.ts
+++ b/packages/core/src/utils/paths.ts
@@ -140,6 +140,19 @@ export function unescapePath(filePath: string): string {
 }
 
 /**
+ * Formats a path for display by optionally shortening the relative path and
+ * appending the absolute path in parentheses so terminals can open it.
+ */
+export function formatDisplayPath(
+  relativePath: string,
+  absolutePath: string,
+  shorten = true,
+): string {
+  const display = shorten ? shortenPath(relativePath) : relativePath;
+  return `${display} (${absolutePath})`;
+}
+
+/**
  * Generates a unique hash for a project based on its root path.
  * @param projectRoot The absolute path to the project's root directory.
  * @returns A SHA256 hash of the project root path.


### PR DESCRIPTION
## Summary
- show both shortened and absolute paths when tools describe files
- add `--no-path-shortening` option and config support
- update Edit and WriteFile tools and tests for new path format
- implement helper `formatDisplayPath`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68688b8494e08331a94501ac3333a7fc