### PR TITLE
Add license header to node version check files

### DIFF
--- a/packages/cli/src/__tests__/nodeVersionWarning.test.ts
+++ b/packages/cli/src/__tests__/nodeVersionWarning.test.ts
@@ -1,0 +1,44 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { getNodeVersionWarning } from '../utils/nodeVersionWarning.js';
+import * as packageUtil from '../utils/package.js';
+
+vi.mock('../utils/package.js');
+
+describe('getNodeVersionWarning', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('returns null when version satisfies requirement', async () => {
+    vi.mocked(packageUtil.getPackageJson).mockResolvedValue({
+      engines: { node: '>=18' },
+    } as packageUtil.PackageJson);
+
+    const warning = await getNodeVersionWarning('18.12.0');
+    expect(warning).toBeNull();
+  });
+
+  it('returns warning when version does not satisfy requirement', async () => {
+    vi.mocked(packageUtil.getPackageJson).mockResolvedValue({
+      engines: { node: '>=20' },
+    } as packageUtil.PackageJson);
+
+    const warning = await getNodeVersionWarning('18.12.0');
+    expect(warning).toContain('>=20');
+  });
+
+  it('returns null when engines.node missing', async () => {
+    vi.mocked(packageUtil.getPackageJson).mockResolvedValue(
+      {} as packageUtil.PackageJson,
+    );
+
+    const warning = await getNodeVersionWarning('18.0.0');
+    expect(warning).toBeNull();
+  });
+});

--- a/packages/cli/src/utils/nodeVersionWarning.ts
+++ b/packages/cli/src/utils/nodeVersionWarning.ts
@@ -1,0 +1,22 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import semver from 'semver';
+import { getPackageJson } from './package.js';
+
+export async function getNodeVersionWarning(
+  currentVersion: string = process.version,
+): Promise<string | null> {
+  const pkgJson = await getPackageJson();
+  const required = pkgJson?.engines?.node;
+  if (!required) {
+    return null;
+  }
+  if (!semver.satisfies(currentVersion, required)) {
+    return `Gemini CLI requires Node.js ${required}. You are using ${currentVersion}.`;
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary
- add a utility to warn if current Node.js version doesn't satisfy package requirements
- test Node.js version warning
- include the standard Apache 2.0 license header in both new files

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68688aabf9c88331b1d0f2ccf8786703