### PR TITLE
Normalize Windows path separators in autocomplete

### DIFF
--- a/packages/cli/src/ui/hooks/atCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/atCommandProcessor.ts
@@ -20,6 +20,10 @@ import {
 } from '../types.js';
 import { UseHistoryManagerReturn } from './useHistoryManager.js';
 
+function normalizePathForWindows(p: string): string {
+  return process.platform === 'win32' ? p.replace(/\\/g, '/') : p;
+}
+
 interface HandleAtCommandParams {
   query: string;
   config: Config;
@@ -191,16 +195,16 @@ export async function handleAtCommand({
       continue;
     }
 
-    let currentPathSpec = pathName;
+    let currentPathSpec = normalizePathForWindows(pathName);
     let resolvedSuccessfully = false;
 
     try {
       const absolutePath = path.resolve(config.getTargetDir(), pathName);
       const stats = await fs.stat(absolutePath);
       if (stats.isDirectory()) {
-        currentPathSpec = pathName.endsWith('/')
-          ? `${pathName}**`
-          : `${pathName}/**`;
+        currentPathSpec = normalizePathForWindows(
+          pathName.endsWith('/') ? `${pathName}**` : `${pathName}/**`,
+        );
         onDebugMessage(
           `Path ${pathName} resolved to directory, using glob: ${currentPathSpec}`,
         );
@@ -228,9 +232,8 @@ export async function handleAtCommand({
               const lines = globResult.llmContent.split('\n');
               if (lines.length > 1 && lines[1]) {
                 const firstMatchAbsolute = lines[1].trim();
-                currentPathSpec = path.relative(
-                  config.getTargetDir(),
-                  firstMatchAbsolute,
+                currentPathSpec = normalizePathForWindows(
+                  path.relative(config.getTargetDir(), firstMatchAbsolute),
                 );
                 onDebugMessage(
                   `Glob search for ${pathName} found ${firstMatchAbsolute}, using relative path: ${currentPathSpec}`,

--- a/packages/cli/src/ui/hooks/useCompletion.ts
+++ b/packages/cli/src/ui/hooks/useCompletion.ts
@@ -22,6 +22,10 @@ import {
 } from '../components/SuggestionsDisplay.js';
 import { SlashCommand } from './slashCommandProcessor.js';
 
+function normalizePathForWindows(p: string): string {
+  return process.platform === 'win32' ? p.replace(/\\/g, '/') : p;
+}
+
 export interface UseCompletionReturn {
   suggestions: Suggestion[];
   activeSuggestionIndex: number;
@@ -254,11 +258,12 @@ export function useCompletion(
           }
 
           if (entry.name.toLowerCase().startsWith(lowerSearchPrefix)) {
+            const suggestionPath = normalizePathForWindows(
+              entryPathRelative + (entry.isDirectory() ? '/' : ''),
+            );
             foundSuggestions.push({
-              label: entryPathRelative + (entry.isDirectory() ? '/' : ''),
-              value: escapePath(
-                entryPathRelative + (entry.isDirectory() ? '/' : ''),
-              ),
+              label: suggestionPath,
+              value: escapePath(suggestionPath),
             });
           }
           if (
@@ -301,7 +306,9 @@ export function useCompletion(
 
       const suggestions: Suggestion[] = files
         .map((file: string) => {
-          const relativePath = path.relative(cwd, file);
+          const relativePath = normalizePathForWindows(
+            path.relative(cwd, file),
+          );
           return {
             label: relativePath,
             value: escapePath(relativePath),

--- a/packages/cli/src/ui/hooks/useCompletion.windows.test.ts
+++ b/packages/cli/src/ui/hooks/useCompletion.windows.test.ts
@@ -1,0 +1,90 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type { Mocked } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useCompletion } from './useCompletion.js';
+import * as fs from 'fs/promises';
+import { FileDiscoveryService } from '@google/gemini-cli-core';
+
+vi.mock('path', async () => {
+  const actual = await vi.importActual<typeof import('path')>('path');
+  return { ...actual.win32, posix: actual.posix, win32: actual.win32 };
+});
+
+vi.mock('fs/promises');
+vi.mock('@google/gemini-cli-core', async () => {
+  const actual = await vi.importActual('@google/gemini-cli-core');
+  return {
+    ...actual,
+    FileDiscoveryService: vi.fn(),
+    isNodeError: vi.fn((e) => e.code === 'ENOENT'),
+    escapePath: vi.fn((p) => p),
+    unescapePath: vi.fn((p) => p),
+    getErrorMessage: vi.fn((e) => e.message),
+  };
+});
+
+const originalPlatform = process.platform;
+
+describe('useCompletion Windows path handling', () => {
+  let mockFileDiscoveryService: Mocked<FileDiscoveryService>;
+  const testCwd = 'C:\\project';
+  const slashCommands = [
+    { name: 'help', description: 'Show help', action: vi.fn() },
+    { name: 'clear', description: 'Clear screen', action: vi.fn() },
+  ];
+  const mockConfig = {
+    getFileFilteringRespectGitIgnore: vi.fn(() => true),
+    getFileService: vi.fn(),
+    getEnableRecursiveFileSearch: vi.fn(() => true),
+  };
+
+  beforeEach(() => {
+    mockFileDiscoveryService = {
+      shouldGitIgnoreFile: vi.fn(() => false),
+      filterFiles: vi.fn((f) => f),
+    } as unknown as Mocked<FileDiscoveryService>;
+    mockConfig.getFileService.mockReturnValue(mockFileDiscoveryService);
+    vi.mocked(FileDiscoveryService).mockImplementation(
+      () => mockFileDiscoveryService,
+    );
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
+    vi.restoreAllMocks();
+  });
+
+  it('returns forward slashes for Windows suggestions', async () => {
+    vi.mocked(fs.readdir).mockResolvedValue([
+      { name: 'src', isDirectory: () => true },
+      { name: 'README.md', isDirectory: () => false },
+    ] as Array<{ name: string; isDirectory: () => boolean }>);
+
+    const { result } = renderHook(() =>
+      useCompletion('@', testCwd, true, slashCommands, mockConfig),
+    );
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 150));
+    });
+
+    expect(result.current.suggestions).toEqual(
+      expect.arrayContaining([
+        { label: 'src/', value: 'src/' },
+        { label: 'README.md', value: 'README.md' },
+      ]),
+    );
+    // ensure no backslashes
+    expect(result.current.suggestions.some((s) => s.label.includes('\\'))).toBe(
+      false,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- return forward slashes on Windows when suggesting @ paths
- ensure @ command glob matches use forward slashes
- test Windows behavior for `useCompletion`
- normalize path spec in atCommandProcessor when resolving directories

## Testing
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6868691cc9b883319d0d07de037b453e