### PR TITLE
Resolve CLI entry path using import.meta.url

### DIFF
--- a/integration-tests/other-cwd.test.js
+++ b/integration-tests/other-cwd.test.js
@@ -1,0 +1,29 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { test } from 'node:test';
+import { strict as assert } from 'assert';
+import { TestRig } from './test-helper.js';
+import { join } from 'path';
+import { execSync } from 'child_process';
+
+// Verify the CLI runs when executed from a directory different than the bundle location
+
+test('cli runs from another cwd', async (t) => {
+  const rig = new TestRig();
+  rig.setup(t.name);
+  rig.createFile('sample.txt', 'hello');
+  rig.mkdir('sub');
+  rig.sync();
+
+  const cwd = join(rig.testDir, 'sub');
+  const output = execSync(
+    `node ${rig.bundlePath} --yolo --prompt "list files"`,
+    { cwd, encoding: 'utf-8' },
+  );
+
+  assert.ok(output.includes('sample.txt'));
+});

--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -6,11 +6,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import './src/gemini.js';
-import { main } from './src/gemini.js';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const { main } = await import(require.resolve('./src/gemini.js'));
 
 // --- Global Entry Point ---
-main().catch((error) => {
+main().catch((error: unknown) => {
   console.error('An unexpected critical error occurred:');
   if (error instanceof Error) {
     console.error(error.stack);


### PR DESCRIPTION
## Summary
- resolve CLI entry via `import.meta.url`
- add integration test to run the CLI from another cwd

## Testing
- `npm test`
- `npm run test:integration:sandbox:none other-cwd` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68688e20dce08331b0bcfdd735fc9e2c