### PR TITLE
Add pnpm global install commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,12 @@ With the Gemini CLI you can:
    npx https://github.com/google-gemini/gemini-cli
    ```
 
-   Or install it with:
+   Alternatively, install it globally with your preferred package manager:
 
    ```bash
    npm install -g @google/gemini-cli
+   # or
+   pnpm add -g @google-gemini/gemini-cli
    gemini
    ```
 

--- a/docs/Uninstall.md
+++ b/docs/Uninstall.md
@@ -1,6 +1,6 @@
 ## Uninstalling the CLI
 
-Your uninstall method depends on how you ran the CLI. Follow the instructions for either npx or a global npm installation.
+Your uninstall method depends on how you ran the CLI. Follow the instructions for either npx or a global npm/pnpm installation.
 
 ### Method 1: Using npx
 
@@ -31,12 +31,13 @@ _PowerShell_
 Remove-Item -Path (Join-Path $env:LocalAppData "npm-cache\_npx") -Recurse -Force
 ```
 
-### Method 2: Using npm (Global Install)
+### Method 2: Using npm or pnpm (Global Install)
 
-If you installed the CLI globally (e.g., `npm install -g @google/gemini-cli`), use the `npm uninstall` command with the `-g` flag to remove it.
+If you installed the CLI globally (e.g., `npm install -g @google/gemini-cli` or `pnpm add -g @google-gemini/gemini-cli`), use the appropriate uninstall command (`npm uninstall -g` or `pnpm remove -g`) to remove it.
 
 ```bash
 npm uninstall -g @google/gemini-cli
+pnpm remove -g @google-gemini/gemini-cli
 ```
 
 This command completely removes the package from your system.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -15,8 +15,10 @@ This is the recommended way for end-users to install Gemini CLI. It involves dow
 - **Global install:**
 
   ```bash
-  # Install the CLI globally
+  # Install the CLI globally with npm
   npm install -g @google/gemini-cli
+  # or use pnpm
+  pnpm add -g @google-gemini/gemini-cli
 
   # Now you can run the CLI from anywhere
   gemini

--- a/docs/npm.md
+++ b/docs/npm.md
@@ -6,7 +6,7 @@ This monorepo contains two main packages: `@google/gemini-cli` and `@google/gemi
 
 This is the main package for the Gemini CLI. It is responsible for the user interface, command parsing, and all other user-facing functionality.
 
-When this package is published, it is bundled into a single executable file. This bundle includes all of the package's dependencies, including `@google/gemini-cli-core`. This means that whether a user installs the package with `npm install -g @google/gemini-cli` or runs it directly with `npx @google/gemini-cli`, they are using this single, self-contained executable.
+When this package is published, it is bundled into a single executable file. This bundle includes all of the package's dependencies, including `@google/gemini-cli-core`. This means that whether a user installs the package with `npm install -g @google/gemini-cli`, `pnpm add -g @google-gemini/gemini-cli`, or runs it directly with `npx @google/gemini-cli`, they are using this single, self-contained executable.
 
 ## `@google/gemini-cli-core`
 
@@ -59,6 +59,7 @@ To install the latest nightly build, use the `@nightly` tag:
 
 ```bash
 npm install -g @google/gemini-cli@nightly
+pnpm add -g @google-gemini/gemini-cli@nightly
 ```
 
 The high-level process is:

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -9,6 +9,8 @@ Before using sandboxing, you need to install and set up the Gemini CLI:
 ```bash
 # install gemini-cli with npm
 npm install -g @google/gemini-cli
+# or pnpm
+pnpm add -g @google-gemini/gemini-cli
 
 # Verify installation
 gemini --version

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -16,7 +16,7 @@ This guide provides solutions to common issues and debugging tips.
 ## Frequently asked questions (FAQs)
 
 - **Q: How do I update Gemini CLI to the latest version?**
-  - A: If installed globally via npm, update Gemini CLI using the command `npm install -g @google/gemini-cli@latest`. If run from source, pull the latest changes from the repository and rebuild using `npm run build`.
+  - A: If installed globally via npm or pnpm, update Gemini CLI using `npm install -g @google/gemini-cli@latest` or `pnpm add -g @google-gemini/gemini-cli@latest`. If run from source, pull the latest changes from the repository and rebuild using `npm run build`.
 
 - **Q: Where are Gemini CLI configuration files stored?**
   - A: The CLI configuration is stored within two `settings.json` files: one in your home directory and one in your project's root directory. In both locations, `settings.json` is found in the `.gemini/` folder. Refer to [CLI Configuration](./cli/configuration.md) for more details.


### PR DESCRIPTION
## Summary
- document pnpm add -g as an install option
- show pnpm in quickstart
- mention npm or pnpm in uninstall instructions

Fixes #2878

## Testing
- `npm run preflight`

------
https://chatgpt.com/codex/tasks/task_e_68688f36f500833184788edede838ce0