### PR TITLE
feat(shell): improve error messages for disallowed commands

### DIFF
--- a/packages/core/src/tools/shell.test.ts
+++ b/packages/core/src/tools/shell.test.ts
@@ -15,8 +15,9 @@ describe('ShellTool', () => {
       getExcludeTools: () => undefined,
     } as Config;
     const shellTool = new ShellTool(config);
-    const isAllowed = shellTool.isCommandAllowed('ls -l');
+    const [isAllowed, reason] = shellTool.isCommandAllowed('ls -l');
     expect(isAllowed).toBe(true);
+    expect(reason).toBe('');
   });
 
   it('should allow a command if it is in the allowed list', async () => {
@@ -25,8 +26,9 @@ describe('ShellTool', () => {
       getExcludeTools: () => undefined,
     } as unknown as Config;
     const shellTool = new ShellTool(config);
-    const isAllowed = shellTool.isCommandAllowed('ls -l');
+    const [isAllowed, reason] = shellTool.isCommandAllowed('ls -l');
     expect(isAllowed).toBe(true);
+    expect(reason).toBe('');
   });
 
   it('should block a command if it is not in the allowed list', async () => {
@@ -35,8 +37,9 @@ describe('ShellTool', () => {
       getExcludeTools: () => undefined,
     } as unknown as Config;
     const shellTool = new ShellTool(config);
-    const isAllowed = shellTool.isCommandAllowed('rm -rf /');
+    const [isAllowed, reason] = shellTool.isCommandAllowed('rm -rf /');
     expect(isAllowed).toBe(false);
+    expect(reason).toBe('Command "rm -rf /" is not on the strict allowlist.');
   });
 
   it('should block a command if it is in the blocked list', async () => {
@@ -45,8 +48,9 @@ describe('ShellTool', () => {
       getExcludeTools: () => ['ShellTool(rm -rf /)'],
     } as unknown as Config;
     const shellTool = new ShellTool(config);
-    const isAllowed = shellTool.isCommandAllowed('rm -rf /');
+    const [isAllowed, reason] = shellTool.isCommandAllowed('rm -rf /');
     expect(isAllowed).toBe(false);
+    expect(reason).toBe('Command "rm -rf /" is on the blocklist.');
   });
 
   it('should allow a command if it is not in the blocked list', async () => {
@@ -55,8 +59,9 @@ describe('ShellTool', () => {
       getExcludeTools: () => ['ShellTool(rm -rf /)'],
     } as unknown as Config;
     const shellTool = new ShellTool(config);
-    const isAllowed = shellTool.isCommandAllowed('ls -l');
+    const [isAllowed, reason] = shellTool.isCommandAllowed('ls -l');
     expect(isAllowed).toBe(true);
+    expect(reason).toBe('');
   });
 
   it('should block a command if it is in both the allowed and blocked lists', async () => {
@@ -65,8 +70,9 @@ describe('ShellTool', () => {
       getExcludeTools: () => ['ShellTool(rm -rf /)'],
     } as unknown as Config;
     const shellTool = new ShellTool(config);
-    const isAllowed = shellTool.isCommandAllowed('rm -rf /');
+    const [isAllowed, reason] = shellTool.isCommandAllowed('rm -rf /');
     expect(isAllowed).toBe(false);
+    expect(reason).toBe('Command "rm -rf /" is on the blocklist.');
   });
 
   it('should allow any command when ShellTool is in coreTools without specific commands', async () => {
@@ -75,8 +81,9 @@ describe('ShellTool', () => {
       getExcludeTools: () => [],
     } as unknown as Config;
     const shellTool = new ShellTool(config);
-    const isAllowed = shellTool.isCommandAllowed('any command');
+    const [isAllowed, reason] = shellTool.isCommandAllowed('any command');
     expect(isAllowed).toBe(true);
+    expect(reason).toBe('');
   });
 
   it('should block any command when ShellTool is in excludeTools without specific commands', async () => {
@@ -85,8 +92,11 @@ describe('ShellTool', () => {
       getExcludeTools: () => ['ShellTool'],
     } as unknown as Config;
     const shellTool = new ShellTool(config);
-    const isAllowed = shellTool.isCommandAllowed('any command');
+    const [isAllowed, reason] = shellTool.isCommandAllowed('any command');
     expect(isAllowed).toBe(false);
+    expect(reason).toBe(
+      'The shell tool is disabled in the current configuration.',
+    );
   });
 
   it('should allow a command if it is in the allowed list using the public-facing name', async () => {
@@ -95,8 +105,9 @@ describe('ShellTool', () => {
       getExcludeTools: () => undefined,
     } as unknown as Config;
     const shellTool = new ShellTool(config);
-    const isAllowed = shellTool.isCommandAllowed('ls -l');
+    const [isAllowed, reason] = shellTool.isCommandAllowed('ls -l');
     expect(isAllowed).toBe(true);
+    expect(reason).toBe('');
   });
 
   it('should block a command if it is in the blocked list using the public-facing name', async () => {
@@ -105,8 +116,9 @@ describe('ShellTool', () => {
       getExcludeTools: () => ['run_shell_command(rm -rf /)'],
     } as unknown as Config;
     const shellTool = new ShellTool(config);
-    const isAllowed = shellTool.isCommandAllowed('rm -rf /');
+    const [isAllowed, reason] = shellTool.isCommandAllowed('rm -rf /');
     expect(isAllowed).toBe(false);
+    expect(reason).toBe('Command "rm -rf /" is on the blocklist.');
   });
 
   it('should block any command when ShellTool is in excludeTools using the public-facing name', async () => {
@@ -115,8 +127,11 @@ describe('ShellTool', () => {
       getExcludeTools: () => ['run_shell_command'],
     } as unknown as Config;
     const shellTool = new ShellTool(config);
-    const isAllowed = shellTool.isCommandAllowed('any command');
+    const [isAllowed, reason] = shellTool.isCommandAllowed('any command');
     expect(isAllowed).toBe(false);
+    expect(reason).toBe(
+      'The shell tool is disabled in the current configuration.',
+    );
   });
 
   it('should block any command if coreTools contains an empty ShellTool command list using the public-facing name', async () => {
@@ -125,8 +140,11 @@ describe('ShellTool', () => {
       getExcludeTools: () => [],
     } as unknown as Config;
     const shellTool = new ShellTool(config);
-    const isAllowed = shellTool.isCommandAllowed('any command');
+    const [isAllowed, reason] = shellTool.isCommandAllowed('any command');
     expect(isAllowed).toBe(false);
+    expect(reason).toBe(
+      'Command "any command" is not on the strict allowlist.',
+    );
   });
 
   it('should block any command if coreTools contains an empty ShellTool command list', async () => {
@@ -135,8 +153,11 @@ describe('ShellTool', () => {
       getExcludeTools: () => [],
     } as unknown as Config;
     const shellTool = new ShellTool(config);
-    const isAllowed = shellTool.isCommandAllowed('any command');
+    const [isAllowed, reason] = shellTool.isCommandAllowed('any command');
     expect(isAllowed).toBe(false);
+    expect(reason).toBe(
+      'Command "any command" is not on the strict allowlist.',
+    );
   });
 
   it('should block a command with extra whitespace if it is in the blocked list', async () => {
@@ -145,8 +166,9 @@ describe('ShellTool', () => {
       getExcludeTools: () => ['ShellTool(rm -rf /)'],
     } as unknown as Config;
     const shellTool = new ShellTool(config);
-    const isAllowed = shellTool.isCommandAllowed(' rm  -rf  / ');
+    const [isAllowed, reason] = shellTool.isCommandAllowed(' rm  -rf  / ');
     expect(isAllowed).toBe(false);
+    expect(reason).toBe('Command "rm -rf /" is on the blocklist.');
   });
 
   it('should allow any command when ShellTool is present with specific commands', async () => {
@@ -155,8 +177,9 @@ describe('ShellTool', () => {
       getExcludeTools: () => [],
     } as unknown as Config;
     const shellTool = new ShellTool(config);
-    const isAllowed = shellTool.isCommandAllowed('any command');
+    const [isAllowed, reason] = shellTool.isCommandAllowed('any command');
     expect(isAllowed).toBe(true);
+    expect(reason).toBe('');
   });
 
   it('should block a command on the blocklist even with a wildcard allow', async () => {
@@ -165,8 +188,9 @@ describe('ShellTool', () => {
       getExcludeTools: () => ['ShellTool(rm -rf /)'],
     } as unknown as Config;
     const shellTool = new ShellTool(config);
-    const isAllowed = shellTool.isCommandAllowed('rm -rf /');
+    const [isAllowed, reason] = shellTool.isCommandAllowed('rm -rf /');
     expect(isAllowed).toBe(false);
+    expect(reason).toBe('Command "rm -rf /" is on the blocklist.');
   });
 
   it('should allow a command that starts with an allowed command prefix', async () => {
@@ -175,10 +199,11 @@ describe('ShellTool', () => {
       getExcludeTools: () => [],
     } as unknown as Config;
     const shellTool = new ShellTool(config);
-    const isAllowed = shellTool.isCommandAllowed(
+    const [isAllowed, reason] = shellTool.isCommandAllowed(
       'gh issue edit 1 --add-label "kind/feature"',
     );
     expect(isAllowed).toBe(true);
+    expect(reason).toBe('');
   });
 
   it('should allow a command that starts with an allowed command prefix using the public-facing name', async () => {
@@ -187,10 +212,11 @@ describe('ShellTool', () => {
       getExcludeTools: () => [],
     } as unknown as Config;
     const shellTool = new ShellTool(config);
-    const isAllowed = shellTool.isCommandAllowed(
+    const [isAllowed, reason] = shellTool.isCommandAllowed(
       'gh issue edit 1 --add-label "kind/feature"',
     );
     expect(isAllowed).toBe(true);
+    expect(reason).toBe('');
   });
 
   it('should not allow a command that starts with an allowed command prefix but is chained with another command', async () => {
@@ -199,8 +225,11 @@ describe('ShellTool', () => {
       getExcludeTools: () => [],
     } as unknown as Config;
     const shellTool = new ShellTool(config);
-    const isAllowed = shellTool.isCommandAllowed('gh issue edit&&rm -rf /');
+    const [isAllowed, reason] = shellTool.isCommandAllowed(
+      'gh issue edit&&rm -rf /',
+    );
     expect(isAllowed).toBe(false);
+    expect(reason).toBe('Command "rm -rf /" is not on the strict allowlist.');
   });
 
   it('should not allow a command that is a prefix of an allowed command', async () => {
@@ -209,8 +238,9 @@ describe('ShellTool', () => {
       getExcludeTools: () => [],
     } as unknown as Config;
     const shellTool = new ShellTool(config);
-    const isAllowed = shellTool.isCommandAllowed('gh issue');
+    const [isAllowed, reason] = shellTool.isCommandAllowed('gh issue');
     expect(isAllowed).toBe(false);
+    expect(reason).toBe('Command "gh issue" is not on the strict allowlist.');
   });
 
   it('should not allow a command that is a prefix of a blocked command', async () => {
@@ -219,8 +249,9 @@ describe('ShellTool', () => {
       getExcludeTools: () => ['run_shell_command(gh issue edit)'],
     } as unknown as Config;
     const shellTool = new ShellTool(config);
-    const isAllowed = shellTool.isCommandAllowed('gh issue');
+    const [isAllowed, reason] = shellTool.isCommandAllowed('gh issue');
     expect(isAllowed).toBe(true);
+    expect(reason).toBe('');
   });
 
   it('should not allow a command that is chained with a pipe', async () => {
@@ -229,8 +260,11 @@ describe('ShellTool', () => {
       getExcludeTools: () => [],
     } as unknown as Config;
     const shellTool = new ShellTool(config);
-    const isAllowed = shellTool.isCommandAllowed('gh issue list | rm -rf /');
+    const [isAllowed, reason] = shellTool.isCommandAllowed(
+      'gh issue list | rm -rf /',
+    );
     expect(isAllowed).toBe(false);
+    expect(reason).toBe('Command "rm -rf /" is not on the strict allowlist.');
   });
 
   it('should not allow a command that is chained with a semicolon', async () => {
@@ -239,8 +273,11 @@ describe('ShellTool', () => {
       getExcludeTools: () => [],
     } as unknown as Config;
     const shellTool = new ShellTool(config);
-    const isAllowed = shellTool.isCommandAllowed('gh issue list; rm -rf /');
+    const [isAllowed, reason] = shellTool.isCommandAllowed(
+      'gh issue list; rm -rf /',
+    );
     expect(isAllowed).toBe(false);
+    expect(reason).toBe('Command "rm -rf /" is not on the strict allowlist.');
   });
 
   it('should block a chained command if any part is blocked', async () => {
@@ -249,8 +286,11 @@ describe('ShellTool', () => {
       getExcludeTools: () => ['run_shell_command(rm)'],
     } as unknown as Config;
     const shellTool = new ShellTool(config);
-    const isAllowed = shellTool.isCommandAllowed('echo "hello" && rm -rf /');
+    const [isAllowed, reason] = shellTool.isCommandAllowed(
+      'echo "hello" && rm -rf /',
+    );
     expect(isAllowed).toBe(false);
+    expect(reason).toBe('Command "rm -rf /" is on the blocklist.');
   });
 
   it('should block a command if its prefix is on the blocklist, even if the command itself is on the allowlist', async () => {
@@ -259,8 +299,9 @@ describe('ShellTool', () => {
       getExcludeTools: () => ['run_shell_command(git)'],
     } as unknown as Config;
     const shellTool = new ShellTool(config);
-    const isAllowed = shellTool.isCommandAllowed('git push');
+    const [isAllowed, reason] = shellTool.isCommandAllowed('git push');
     expect(isAllowed).toBe(false);
+    expect(reason).toBe('Command "git push" is on the blocklist.');
   });
 
   it('should be case-sensitive in its matching', async () => {
@@ -269,8 +310,11 @@ describe('ShellTool', () => {
       getExcludeTools: () => [],
     } as unknown as Config;
     const shellTool = new ShellTool(config);
-    const isAllowed = shellTool.isCommandAllowed('ECHO "hello"');
+    const [isAllowed, reason] = shellTool.isCommandAllowed('ECHO "hello"');
     expect(isAllowed).toBe(false);
+    expect(reason).toBe(
+      'Command "ECHO "hello"" is not on the strict allowlist.',
+    );
   });
 
   it('should correctly handle commands with extra whitespace around chaining operators', async () => {
@@ -279,8 +323,10 @@ describe('ShellTool', () => {
       getExcludeTools: () => ['run_shell_command(rm)'],
     } as unknown as Config;
     const shellTool = new ShellTool(config);
-    const isAllowed = shellTool.isCommandAllowed('ls -l  ;  rm -rf /');
+    const [isAllowed, reason] =
+      shellTool.isCommandAllowed('ls -l  ;  rm -rf /');
     expect(isAllowed).toBe(false);
+    expect(reason).toBe('Command "rm -rf /" is on the blocklist.');
   });
 
   it('should allow a chained command if all parts are allowed', async () => {
@@ -292,8 +338,11 @@ describe('ShellTool', () => {
       getExcludeTools: () => [],
     } as unknown as Config;
     const shellTool = new ShellTool(config);
-    const isAllowed = shellTool.isCommandAllowed('echo "hello" && ls -l');
+    const [isAllowed, reason] = shellTool.isCommandAllowed(
+      'echo "hello" && ls -l',
+    );
     expect(isAllowed).toBe(true);
+    expect(reason).toBe('');
   });
 
   it('should block a command with command substitution using backticks', async () => {
@@ -302,8 +351,9 @@ describe('ShellTool', () => {
       getExcludeTools: () => [],
     } as unknown as Config;
     const shellTool = new ShellTool(config);
-    const isAllowed = shellTool.isCommandAllowed('echo `rm -rf /`');
+    const [isAllowed, reason] = shellTool.isCommandAllowed('echo `rm -rf /`');
     expect(isAllowed).toBe(false);
+    expect(reason).toBe('Command substitution is not allowed.');
   });
 
   it('should block a command with command substitution using $()', async () => {
@@ -312,8 +362,9 @@ describe('ShellTool', () => {
       getExcludeTools: () => [],
     } as unknown as Config;
     const shellTool = new ShellTool(config);
-    const isAllowed = shellTool.isCommandAllowed('echo $(rm -rf /)');
+    const [isAllowed, reason] = shellTool.isCommandAllowed('echo $(rm -rf /)');
     expect(isAllowed).toBe(false);
+    expect(reason).toBe('Command substitution is not allowed.');
   });
 
   it('should allow a command with I/O redirection', async () => {
@@ -322,8 +373,11 @@ describe('ShellTool', () => {
       getExcludeTools: () => [],
     } as unknown as Config;
     const shellTool = new ShellTool(config);
-    const isAllowed = shellTool.isCommandAllowed('echo "hello" > file.txt');
+    const [isAllowed, reason] = shellTool.isCommandAllowed(
+      'echo "hello" > file.txt',
+    );
     expect(isAllowed).toBe(true);
+    expect(reason).toBe('');
   });
 
   it('should not allow a command that is chained with a double pipe', async () => {
@@ -332,7 +386,10 @@ describe('ShellTool', () => {
       getExcludeTools: () => [],
     } as unknown as Config;
     const shellTool = new ShellTool(config);
-    const isAllowed = shellTool.isCommandAllowed('gh issue list || rm -rf /');
+    const [isAllowed, reason] = shellTool.isCommandAllowed(
+      'gh issue list || rm -rf /',
+    );
     expect(isAllowed).toBe(false);
+    expect(reason).toBe('Command "rm -rf /" is not on the strict allowlist.');
   });
 });

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -114,10 +114,10 @@ Process Group PGID: Process group started or \`(none)\``,
    * @param command The shell command string to validate
    * @returns True if the command is allowed to execute, false otherwise
    */
-  isCommandAllowed(command: string): boolean {
+  isCommandAllowed(command: string): [boolean, string] {
     // 0. Disallow command substitution
     if (command.includes('$(') || command.includes('`')) {
-      return false;
+      return [false, 'Command substitution is not allowed.'];
     }
 
     const SHELL_TOOL_NAMES = [ShellTool.name, ShellTool.Name];
@@ -157,7 +157,10 @@ Process Group PGID: Process group started or \`(none)\``,
 
     // 1. Check if the shell tool is globally disabled.
     if (SHELL_TOOL_NAMES.some((name) => excludeTools.includes(name))) {
-      return false;
+      return [
+        false,
+        'The shell tool is disabled in the current configuration.',
+      ];
     }
 
     const blockedCommands = new Set(extractCommands(excludeTools));
@@ -176,7 +179,7 @@ Process Group PGID: Process group started or \`(none)\``,
         isPrefixedBy(cmd, blocked),
       );
       if (isBlocked) {
-        return false;
+        return [false, `Command "${cmd}" is on the blocklist.`];
       }
 
       // 3. If in strict allow-list mode, check if the command is permitted.
@@ -187,18 +190,19 @@ Process Group PGID: Process group started or \`(none)\``,
           isPrefixedBy(cmd, allowed),
         );
         if (!isAllowed) {
-          return false;
+          return [false, `Command "${cmd}" is not on the strict allowlist.`];
         }
       }
     }
 
     // 4. If all checks pass, the command is allowed.
-    return true;
+    return [true, ''];
   }
 
   validateToolParams(params: ShellToolParams): string | null {
-    if (!this.isCommandAllowed(params.command)) {
-      return `Command is not allowed: ${params.command}`;
+    const [isAllowed, reason] = this.isCommandAllowed(params.command);
+    if (!isAllowed) {
+      return `Command is not allowed: ${reason}`;
     }
     if (
       !SchemaValidator.validate(


### PR DESCRIPTION
This pull request addresses the issue 'Improve Error Messages in isCommandAllowed in shell.ts'.

This commit improves the error messages for disallowed shell commands
by providing more specific reasons why a command was blocked.

The  method in  now returns a tuple
containing a boolean and a string. The string provides the reason
for disallowing the command. This reason is then used in
 to give the user a more informative error
message.

The tests in  have been updated to reflect these
changes and to assert the new error messages.