### PR TITLE
Add option to include git-ignored files

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,13 @@ gemini
 > Give me a summary of all of the changes that went in yesterday
 ```
 
+### Reading git-ignored files
+
+By default, the CLI and its tools skip files listed in your `.gitignore`. To
+include these files in commands like `@` or `read_many_files`, enable the
+`includeIgnored` setting under `fileFiltering` in your `.gemini/settings.json`
+or pass `include_ignored: true` to the `read_many_files` tool.
+
 ### Next steps
 
 - Learn how to [contribute to or build from the source](./CONTRIBUTING.md).

--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -56,11 +56,13 @@ In addition to a project settings file, a project's `.gemini` directory can cont
   - **Properties:**
     - **`respectGitIgnore`** (boolean): Whether to respect .gitignore patterns when discovering files. When set to `true`, git-ignored files (like `node_modules/`, `dist/`, `.env`) are automatically excluded from @ commands and file listing operations.
     - **`enableRecursiveFileSearch`** (boolean): Whether to enable searching recursively for filenames under the current tree when completing @ prefixes in the prompt.
+    - **`includeIgnored`** (boolean): Include files that match `.gitignore` when using `@` commands or file discovery tools.
   - **Example:**
     ```json
     "fileFiltering": {
       "respectGitIgnore": true,
-      "enableRecursiveFileSearch": false
+      "enableRecursiveFileSearch": false,
+      "includeIgnored": true
     }
     ```
 

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -234,6 +234,7 @@ export async function loadCliConfig(
       respectGitIgnore: settings.fileFiltering?.respectGitIgnore,
       enableRecursiveFileSearch:
         settings.fileFiltering?.enableRecursiveFileSearch,
+      includeIgnored: settings.fileFiltering?.includeIgnored,
     },
     checkpointing: argv.checkpointing || settings.checkpointing?.enabled,
     proxy:

--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -59,6 +59,7 @@ export interface Settings {
   fileFiltering?: {
     respectGitIgnore?: boolean;
     enableRecursiveFileSearch?: boolean;
+    includeIgnored?: boolean;
   };
 
   // UI setting. Does not display the ANSI-controlled terminal title.

--- a/packages/cli/src/ui/hooks/atCommandProcessor.test.ts
+++ b/packages/cli/src/ui/hooks/atCommandProcessor.test.ts
@@ -21,6 +21,7 @@ const mockConfig = {
   isSandboxed: vi.fn(() => false),
   getFileService: vi.fn(),
   getFileFilteringRespectGitIgnore: vi.fn(() => true),
+  getFileFilteringIncludeIgnored: vi.fn(() => false),
   getEnableRecursiveFileSearch: vi.fn(() => true),
 } as unknown as Config;
 
@@ -103,6 +104,7 @@ describe('handleAtCommand', () => {
     mockConfig.getFileService = vi
       .fn()
       .mockReturnValue(mockFileDiscoveryService);
+    mockConfig.getFileFilteringIncludeIgnored = vi.fn(() => false);
   });
 
   afterEach(() => {
@@ -171,7 +173,7 @@ describe('handleAtCommand', () => {
       125,
     );
     expect(mockReadManyFilesExecute).toHaveBeenCalledWith(
-      { paths: [filePath], respectGitIgnore: true },
+      { paths: [filePath], respectGitIgnore: true, includeIgnored: false },
       abortController.signal,
     );
     expect(mockAddItem).toHaveBeenCalledWith(
@@ -217,7 +219,7 @@ describe('handleAtCommand', () => {
       126,
     );
     expect(mockReadManyFilesExecute).toHaveBeenCalledWith(
-      { paths: [resolvedGlob], respectGitIgnore: true },
+      { paths: [resolvedGlob], respectGitIgnore: true, includeIgnored: false },
       abortController.signal,
     );
     expect(mockOnDebugMessage).toHaveBeenCalledWith(
@@ -318,7 +320,7 @@ describe('handleAtCommand', () => {
       signal: abortController.signal,
     });
     expect(mockReadManyFilesExecute).toHaveBeenCalledWith(
-      { paths: [unescapedPath], respectGitIgnore: true },
+      { paths: [unescapedPath], respectGitIgnore: true, includeIgnored: false },
       abortController.signal,
     );
   });
@@ -347,7 +349,7 @@ describe('handleAtCommand', () => {
       signal: abortController.signal,
     });
     expect(mockReadManyFilesExecute).toHaveBeenCalledWith(
-      { paths: [file1, file2], respectGitIgnore: true },
+      { paths: [file1, file2], respectGitIgnore: true, includeIgnored: false },
       abortController.signal,
     );
     expect(result.processedQuery).toEqual([
@@ -389,7 +391,7 @@ describe('handleAtCommand', () => {
       signal: abortController.signal,
     });
     expect(mockReadManyFilesExecute).toHaveBeenCalledWith(
-      { paths: [file1, file2], respectGitIgnore: true },
+      { paths: [file1, file2], respectGitIgnore: true, includeIgnored: false },
       abortController.signal,
     );
     expect(result.processedQuery).toEqual([
@@ -454,7 +456,7 @@ describe('handleAtCommand', () => {
     });
 
     expect(mockReadManyFilesExecute).toHaveBeenCalledWith(
-      { paths: [file1, resolvedFile2], respectGitIgnore: true },
+      { paths: [file1, resolvedFile2], respectGitIgnore: true, includeIgnored: false },
       abortController.signal,
     );
     expect(result.processedQuery).toEqual([
@@ -556,7 +558,7 @@ describe('handleAtCommand', () => {
       // If the mock is simpler, it might use queryPath if stat(queryPath) succeeds.
       // The most important part is that *some* version of the path that leads to the content is used.
       // Let's assume it uses the path from the query if stat confirms it exists (even if different case on disk)
-      { paths: [queryPath], respectGitIgnore: true },
+      { paths: [queryPath], respectGitIgnore: true, includeIgnored: false },
       abortController.signal,
     );
     expect(mockAddItem).toHaveBeenCalledWith(
@@ -597,6 +599,7 @@ describe('handleAtCommand', () => {
 
       expect(mockFileDiscoveryService.shouldGitIgnoreFile).toHaveBeenCalledWith(
         gitIgnoredFile,
+        false,
       );
       expect(mockOnDebugMessage).toHaveBeenCalledWith(
         `Path ${gitIgnoredFile} is git-ignored and will be skipped.`,
@@ -606,6 +609,35 @@ describe('handleAtCommand', () => {
       );
       expect(mockReadManyFilesExecute).not.toHaveBeenCalled();
       expect(result.processedQuery).toEqual([{ text: query }]);
+      expect(result.shouldProceed).toBe(true);
+    });
+
+    it('should include git-ignored files when includeIgnored is true', async () => {
+      const gitIgnoredFile = 'debug.log';
+      const query = `@${gitIgnoredFile}`;
+
+      mockConfig.getFileFilteringIncludeIgnored = vi.fn(() => true);
+      mockFileDiscoveryService.shouldGitIgnoreFile.mockImplementation(
+        (_p, includeIgnored) => !includeIgnored,
+      );
+      mockReadManyFilesExecute.mockResolvedValue({
+        llmContent: [`--- ${gitIgnoredFile} ---\n\nlog\n\n`],
+        returnDisplay: 'Read 1 file.',
+      });
+
+      const result = await handleAtCommand({
+        query,
+        config: mockConfig,
+        addItem: mockAddItem,
+        onDebugMessage: mockOnDebugMessage,
+        messageId: 250,
+        signal: abortController.signal,
+      });
+
+      expect(mockReadManyFilesExecute).toHaveBeenCalledWith(
+        { paths: [gitIgnoredFile], respectGitIgnore: true, includeIgnored: true },
+        abortController.signal,
+      );
       expect(result.shouldProceed).toBe(true);
     });
 
@@ -631,9 +663,10 @@ describe('handleAtCommand', () => {
 
       expect(mockFileDiscoveryService.shouldGitIgnoreFile).toHaveBeenCalledWith(
         validFile,
+        false,
       );
       expect(mockReadManyFilesExecute).toHaveBeenCalledWith(
-        { paths: [validFile], respectGitIgnore: true },
+        { paths: [validFile], respectGitIgnore: true, includeIgnored: false },
         abortController.signal,
       );
       expect(result.processedQuery).toEqual([
@@ -671,9 +704,11 @@ describe('handleAtCommand', () => {
 
       expect(mockFileDiscoveryService.shouldGitIgnoreFile).toHaveBeenCalledWith(
         validFile,
+        false,
       );
       expect(mockFileDiscoveryService.shouldGitIgnoreFile).toHaveBeenCalledWith(
         gitIgnoredFile,
+        false,
       );
       expect(mockOnDebugMessage).toHaveBeenCalledWith(
         `Path ${gitIgnoredFile} is git-ignored and will be skipped.`,
@@ -682,7 +717,7 @@ describe('handleAtCommand', () => {
         'Ignored 1 git-ignored files: .env',
       );
       expect(mockReadManyFilesExecute).toHaveBeenCalledWith(
-        { paths: [validFile], respectGitIgnore: true },
+        { paths: [validFile], respectGitIgnore: true, includeIgnored: false },
         abortController.signal,
       );
       expect(result.processedQuery).toEqual([
@@ -712,6 +747,7 @@ describe('handleAtCommand', () => {
 
       expect(mockFileDiscoveryService.shouldGitIgnoreFile).toHaveBeenCalledWith(
         gitFile,
+        false,
       );
       expect(mockOnDebugMessage).toHaveBeenCalledWith(
         `Path ${gitFile} is git-ignored and will be skipped.`,

--- a/packages/cli/src/ui/hooks/atCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/atCommandProcessor.ts
@@ -137,6 +137,7 @@ export async function handleAtCommand({
   // Get centralized file discovery service
   const fileDiscovery = config.getFileService();
   const respectGitIgnore = config.getFileFilteringRespectGitIgnore();
+  const includeIgnored = config.getFileFilteringIncludeIgnored();
 
   const pathSpecsToRead: string[] = [];
   const atPathToResolvedSpecMap = new Map<string, string>();
@@ -182,7 +183,7 @@ export async function handleAtCommand({
     }
 
     // Check if path should be ignored by git
-    if (fileDiscovery.shouldGitIgnoreFile(pathName)) {
+    if (fileDiscovery.shouldGitIgnoreFile(pathName, includeIgnored)) {
       const reason = respectGitIgnore
         ? 'git-ignored and will be skipped'
         : 'ignored by custom patterns';
@@ -350,6 +351,7 @@ export async function handleAtCommand({
   const toolArgs = {
     paths: pathSpecsToRead,
     respectGitIgnore, // Use configuration setting
+    includeIgnored,
   };
   let toolCallDisplay: IndividualToolCallDisplay;
 

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -122,6 +122,7 @@ export interface ConfigParameters {
   fileFiltering?: {
     respectGitIgnore?: boolean;
     enableRecursiveFileSearch?: boolean;
+    includeIgnored?: boolean;
   };
   checkpointing?: boolean;
   proxy?: string;
@@ -159,6 +160,7 @@ export class Config {
   private readonly fileFiltering: {
     respectGitIgnore: boolean;
     enableRecursiveFileSearch: boolean;
+    includeIgnored: boolean;
   };
   private fileDiscoveryService: FileDiscoveryService | null = null;
   private gitService: GitService | undefined = undefined;
@@ -203,6 +205,7 @@ export class Config {
       respectGitIgnore: params.fileFiltering?.respectGitIgnore ?? true,
       enableRecursiveFileSearch:
         params.fileFiltering?.enableRecursiveFileSearch ?? true,
+      includeIgnored: params.fileFiltering?.includeIgnored ?? false,
     };
     this.checkpointing = params.checkpointing ?? false;
     this.proxy = params.proxy;
@@ -412,6 +415,10 @@ export class Config {
 
   getFileFilteringRespectGitIgnore(): boolean {
     return this.fileFiltering.respectGitIgnore;
+  }
+
+  getFileFilteringIncludeIgnored(): boolean {
+    return this.fileFiltering.includeIgnored;
   }
 
   getCheckpointingEnabled(): boolean {

--- a/packages/core/src/services/fileDiscoveryService.test.ts
+++ b/packages/core/src/services/fileDiscoveryService.test.ts
@@ -92,6 +92,19 @@ describe('FileDiscoveryService', () => {
       expect(filtered).toEqual(files);
     });
 
+    it('should include files when includeIgnored is true', () => {
+      const files = [
+        'node_modules/package/index.js',
+        'src/index.ts',
+      ];
+      mockGitIgnoreParser.isIgnored.mockReturnValue(true);
+      const filtered = service.filterFiles(files, {
+        respectGitIgnore: true,
+        includeIgnored: true,
+      });
+      expect(filtered).toEqual(files);
+    });
+
     it('should handle empty file list', () => {
       const filtered = service.filterFiles([]);
       expect(filtered).toEqual([]);
@@ -114,6 +127,12 @@ describe('FileDiscoveryService', () => {
 
     it('should return false for non-ignored files', () => {
       expect(service.shouldGitIgnoreFile('src/index.ts')).toBe(false);
+    });
+
+    it('should return false when includeIgnored is true', () => {
+      expect(
+        service.shouldGitIgnoreFile('node_modules/package/index.js', true),
+      ).toBe(false);
     });
   });
 

--- a/packages/core/src/services/fileDiscoveryService.ts
+++ b/packages/core/src/services/fileDiscoveryService.ts
@@ -13,6 +13,7 @@ const GEMINI_IGNORE_FILE_NAME = '.geminiignore';
 export interface FilterFilesOptions {
   respectGitIgnore?: boolean;
   respectGeminiIgnore?: boolean;
+  includeIgnored?: boolean;
 }
 
 export class FileDiscoveryService {
@@ -48,10 +49,14 @@ export class FileDiscoveryService {
     options: FilterFilesOptions = {
       respectGitIgnore: true,
       respectGeminiIgnore: true,
+      includeIgnored: false,
     },
   ): string[] {
     return filePaths.filter((filePath) => {
-      if (options.respectGitIgnore && this.shouldGitIgnoreFile(filePath)) {
+      if (
+        options.respectGitIgnore &&
+        this.shouldGitIgnoreFile(filePath, options.includeIgnored)
+      ) {
         return false;
       }
       if (
@@ -67,7 +72,8 @@ export class FileDiscoveryService {
   /**
    * Checks if a single file should be git-ignored
    */
-  shouldGitIgnoreFile(filePath: string): boolean {
+  shouldGitIgnoreFile(filePath: string, includeIgnored = false): boolean {
+    if (includeIgnored) return false;
     if (this.gitIgnoreFilter) {
       return this.gitIgnoreFilter.isIgnored(filePath);
     }

--- a/packages/core/src/tools/read-many-files.test.ts
+++ b/packages/core/src/tools/read-many-files.test.ts
@@ -399,5 +399,14 @@ describe('ReadManyFilesTool', () => {
       expect(result.returnDisplay).not.toContain('foo.quux');
       expect(result.returnDisplay).toContain('bar.ts');
     });
+
+    it('should include git-ignored .log files when include_ignored is true', async () => {
+      fs.mkdirSync(path.join(tempRootDir, '.git'));
+      fs.writeFileSync(path.join(tempRootDir, '.gitignore'), '*.log');
+      createFile('debug.log', 'hello');
+      const params = { paths: ['*.log'], include_ignored: true };
+      const result = await tool.execute(params, new AbortController().signal);
+      expect(result.llmContent).toEqual(['--- debug.log ---\n\nhello\n\n']);
+    });
   });
 });

--- a/packages/core/src/tools/read-many-files.ts
+++ b/packages/core/src/tools/read-many-files.ts
@@ -65,6 +65,11 @@ export interface ReadManyFilesParams {
    * Optional. Whether to respect .gitignore patterns. Defaults to true.
    */
   respect_git_ignore?: boolean;
+
+  /**
+   * Optional. Include files that match .gitignore patterns. Defaults to false.
+   */
+  include_ignored?: boolean;
 }
 
 /**
@@ -176,6 +181,12 @@ export class ReadManyFilesTool extends BaseTool<
             'Optional. Whether to respect .gitignore patterns when discovering files. Only available in git repositories. Defaults to true.',
           default: true,
         },
+        include_ignored: {
+          type: 'boolean',
+          description:
+            'Optional. Include files that match .gitignore patterns. Defaults to false.',
+          default: false,
+        },
       },
       required: ['paths'],
     };
@@ -244,6 +255,12 @@ Use this tool when the user's query implies needing the content of several files
     ) {
       return 'If provided, "exclude" must be an array of strings/glob patterns.';
     }
+    if (
+      params.include_ignored !== undefined &&
+      typeof params.include_ignored !== 'boolean'
+    ) {
+      return 'If provided, "include_ignored" must be a boolean.';
+    }
     return null;
   }
 
@@ -293,10 +310,13 @@ Use this tool when the user's query implies needing the content of several files
       exclude = [],
       useDefaultExcludes = true,
       respect_git_ignore = true,
+      include_ignored = false,
     } = params;
 
     const respectGitIgnore =
       respect_git_ignore ?? this.config.getFileFilteringRespectGitIgnore();
+    const includeIgnored =
+      include_ignored ?? this.config.getFileFilteringIncludeIgnored();
 
     // Get centralized file discovery service
     const fileDiscovery = this.config.getFileService();
@@ -336,6 +356,7 @@ Use this tool when the user's query implies needing the content of several files
               entries.map((p) => path.relative(toolBaseDir, p)),
               {
                 respectGitIgnore,
+                includeIgnored,
               },
             )
             .map((p) => path.resolve(toolBaseDir, p))

--- a/packages/core/src/utils/gitIgnoreParser.ts
+++ b/packages/core/src/utils/gitIgnoreParser.ts
@@ -10,7 +10,7 @@ import ignore, { type Ignore } from 'ignore';
 import { isGitRepository } from './gitUtils.js';
 
 export interface GitIgnoreFilter {
-  isIgnored(filePath: string): boolean;
+  isIgnored(filePath: string, includeIgnored?: boolean): boolean;
   getPatterns(): string[];
 }
 
@@ -56,7 +56,10 @@ export class GitIgnoreParser implements GitIgnoreFilter {
     this.patterns.push(...patterns);
   }
 
-  isIgnored(filePath: string): boolean {
+  isIgnored(filePath: string, includeIgnored = false): boolean {
+    if (includeIgnored) {
+      return false;
+    }
     const relativePath = path.isAbsolute(filePath)
       ? path.relative(this.projectRoot, filePath)
       : filePath;


### PR DESCRIPTION
## Summary
- extend gitIgnoreParser with `includeIgnored` flag
- expose option in file discovery service and `read_many_files` tool
- update at command processor to use the flag
- document how to read ignored files
- support config includeIgnored setting
- add tests for reading `.log` files

## Testing
- `npm run build --workspaces`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68689646d6d08331a0bbb4664789a584