### PR TITLE
Update auto-accept indicator text

### DIFF
--- a/packages/cli/src/ui/components/AutoAcceptIndicator.tsx
+++ b/packages/cli/src/ui/components/AutoAcceptIndicator.tsx
@@ -22,9 +22,10 @@ export const AutoAcceptIndicator: React.FC<AutoAcceptIndicatorProps> = ({
 
   switch (approvalMode) {
     case ApprovalMode.AUTO_EDIT:
+      // Show when edits are auto-accepted
       textColor = Colors.AccentGreen;
-      textContent = 'accepting edits';
-      subText = ' (shift + tab to toggle)';
+      textContent = 'auto-accepting edits (shift+tab to disable)';
+      subText = '';
       break;
     case ApprovalMode.YOLO:
       textColor = Colors.AccentRed;

--- a/packages/cli/src/ui/components/Help.tsx
+++ b/packages/cli/src/ui/components/Help.tsx
@@ -119,7 +119,7 @@ export const Help: React.FC<Help> = ({ commands }) => (
       <Text bold color={Colors.AccentPurple}>
         Shift+Tab
       </Text>{' '}
-      - Toggle auto-accepting edits
+      - Disable auto-accepting edits
     </Text>
     <Text color={Colors.Foreground}>
       <Text bold color={Colors.AccentPurple}>


### PR DESCRIPTION
## Summary
- clarify auto accept indicator text and help menu
- add comment about auto accept indicator

## Testing
- `npm test --workspace packages/cli` *(fails: Failed to resolve entry for package `@google/gemini-cli-core`)*

------
https://chatgpt.com/codex/tasks/task_e_6868964611e883319006aa1854e3d729

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the text in the auto-accept indicator to clarify when edits are being auto-accepted and how to disable this mode.
  * Improved the description of the "Shift+Tab" keyboard shortcut in the help section for better clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->