### PR TITLE
Add DEBUG_SHOW_MCP_LOGS control for MCP stderr

### DIFF
--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -277,6 +277,9 @@ The CLI automatically loads environment variables from an `.env` file. The loadi
 - **`CODE_ASSIST_ENDPOINT`**:
   - Specifies the endpoint for the code assist server.
   - This is useful for development and testing.
+- **`DEBUG_SHOW_MCP_LOGS`**:
+  - When set to any value, stderr output from MCP servers is logged for debugging.
+  - By default these logs are suppressed.
 
 ## Command-Line Arguments
 

--- a/packages/core/src/tools/mcp-client.test.ts
+++ b/packages/core/src/tools/mcp-client.test.ts
@@ -650,6 +650,42 @@ describe('discoverMcpTools', () => {
       clientInstances[clientInstances.length - 1]?.value;
     expect(lastClientInstance?.onerror).toEqual(expect.any(Function));
   });
+
+  it('should suppress MCP stderr logs by default', async () => {
+    const serverConfig: MCPServerConfig = { command: './mcp-stdio' };
+    mockConfig.getMcpServers.mockReturnValue({ stdio: serverConfig });
+    const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {});
+
+    await discoverMcpTools(
+      mockConfig.getMcpServers() ?? {},
+      mockConfig.getMcpServerCommand(),
+      mockToolRegistry as any,
+    );
+
+    const stderrCallback = mockGlobalStdioStderrOn.mock.calls[0][1];
+    debugSpy.mockClear();
+    stderrCallback(Buffer.from('oops'));
+    expect(debugSpy).not.toHaveBeenCalled();
+  });
+
+  it('should log MCP stderr when DEBUG_SHOW_MCP_LOGS is true', async () => {
+    process.env.DEBUG_SHOW_MCP_LOGS = '1';
+    const serverConfig: MCPServerConfig = { command: './mcp-stdio' };
+    mockConfig.getMcpServers.mockReturnValue({ stdio: serverConfig });
+    const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {});
+
+    await discoverMcpTools(
+      mockConfig.getMcpServers() ?? {},
+      mockConfig.getMcpServerCommand(),
+      mockToolRegistry as any,
+    );
+
+    const stderrCallback = mockGlobalStdioStderrOn.mock.calls[0][1];
+    debugSpy.mockClear();
+    stderrCallback(Buffer.from('oops'));
+    expect(debugSpy).toHaveBeenCalled();
+    delete process.env.DEBUG_SHOW_MCP_LOGS;
+  });
 });
 
 describe('sanitizeParameters', () => {

--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -271,10 +271,12 @@ async function connectAndDiscover(
 
   if (transport instanceof StdioClientTransport && transport.stderr) {
     transport.stderr.on('data', (data) => {
-      const stderrStr = data.toString();
-      // Filter out verbose INFO logs from some MCP servers
-      if (!stderrStr.includes('] INFO')) {
-        console.debug(`MCP STDERR (${mcpServerName}):`, stderrStr);
+      if (process.env.DEBUG_SHOW_MCP_LOGS) {
+        const stderrStr = data.toString();
+        // Filter out verbose INFO logs from some MCP servers
+        if (!stderrStr.includes('] INFO')) {
+          console.debug(`MCP STDERR (${mcpServerName}):`, stderrStr);
+        }
       }
     });
   }


### PR DESCRIPTION
## Summary
- gate MCP stderr logging behind `DEBUG_SHOW_MCP_LOGS`
- test new env var behavior
- document the env var in configuration docs

## Testing
- `npm test` in `packages/core`


------
https://chatgpt.com/codex/tasks/task_e_68689645e9848331af9a430b80812067