### PR TITLE
Add workspace root option

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,13 @@ gemini
 > Give me a summary of all of the changes that went in yesterday
 ```
 
+If you need to run the CLI while pointing to a different project directory, use
+the `--workspace-root` option:
+
+```sh
+gemini --workspace-root ../other-project
+```
+
 ### Next steps
 
 - Learn how to [contribute to or build from the source](./CONTRIBUTING.md).

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -1,0 +1,13 @@
+# Debugging Gemini CLI
+
+This guide collects tips for troubleshooting and running the CLI in special scenarios.
+
+## Running from a custom workspace
+
+By default, Gemini CLI resolves configuration and context files relative to the current working directory. When invoking the CLI from another location (for example, from within an IDE or script), use the `--workspace-root <dir>` option to specify the project root:
+
+```bash
+gemini --workspace-root /path/to/project
+```
+
+All settings and context files will be loaded from the provided directory.

--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -9,8 +9,23 @@
 import './src/gemini.js';
 import { main } from './src/gemini.js';
 
+function getWorkspaceRootArg(): string | undefined {
+  const args = process.argv.slice(2);
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === '--workspace-root' && i + 1 < args.length) {
+      return args[i + 1];
+    }
+    if (arg.startsWith('--workspace-root=')) {
+      return arg.substring('--workspace-root='.length);
+    }
+  }
+  return undefined;
+}
+
 // --- Global Entry Point ---
-main().catch((error) => {
+const workspaceRoot = getWorkspaceRootArg();
+main(workspaceRoot).catch((error) => {
   console.error('An unexpected critical error occurred:');
   if (error instanceof Error) {
     console.error(error.stack);

--- a/packages/cli/src/__tests__/workspaceRoot.test.ts
+++ b/packages/cli/src/__tests__/workspaceRoot.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import path from 'node:path';
+import { tmpdir } from 'node:os';
+import fs from 'node:fs';
+
+import { main } from '../gemini.js';
+import { loadSettings } from '../config/settings.js';
+import { loadExtensions } from '../config/extension.js';
+import { loadCliConfig } from '../config/config.js';
+
+vi.mock('../config/settings.js', async (importActual) => {
+  const actual = await importActual<typeof import('../config/settings.js')>();
+  return {
+    ...actual,
+    loadSettings: vi.fn(() =>
+      new actual.LoadedSettings(
+        { path: '', settings: {} },
+        { path: '', settings: {} },
+        [],
+      ),
+    ),
+  };
+});
+
+vi.mock('../config/extension.js', () => ({
+  loadExtensions: vi.fn(() => []),
+}));
+
+const observedCwds: string[] = [];
+vi.mock('../config/config.js', () => ({
+  loadCliConfig: vi.fn(async () => {
+    observedCwds.push(process.cwd());
+    return {
+      getSandbox: () => false,
+      getQuestion: () => '',
+    };
+  }),
+}));
+
+vi.mock('../utils/startupWarnings.js', () => ({
+  getStartupWarnings: vi.fn(async () => []),
+}));
+
+vi.mock('ink', () => ({
+  render: vi.fn(),
+}));
+
+vi.mock('../utils/sandbox.js', () => ({
+  start_sandbox: vi.fn(),
+}));
+
+vi.mock('../utils/cleanup.js', () => ({
+  cleanupCheckpoints: vi.fn(),
+}));
+
+describe('workspace-root option', () => {
+  const originalCwd = process.cwd();
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    observedCwds.length = 0;
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+  });
+
+  it('changes file resolution to the provided workspace root', async () => {
+    const dir = fs.mkdtempSync(path.join(tmpdir(), 'gemini-ws-'));
+    try {
+      await main(dir);
+    } catch {
+      // ignore errors from incomplete mocks
+    }
+
+    expect(loadSettings).toHaveBeenCalledWith(dir);
+    expect(loadExtensions).toHaveBeenCalledWith(dir);
+    expect(observedCwds[0]).toBe(dir);
+
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+});

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -82,8 +82,15 @@ async function relaunchWithAdditionalArgs(additionalArgs: string[]) {
   process.exit(0);
 }
 
-export async function main() {
-  const workspaceRoot = process.cwd();
+import path from 'node:path';
+
+export async function main(workspaceRootArg?: string) {
+  const workspaceRoot = workspaceRootArg
+    ? path.resolve(workspaceRootArg)
+    : process.cwd();
+  if (workspaceRootArg) {
+    process.chdir(workspaceRoot);
+  }
   const settings = loadSettings(workspaceRoot);
 
   await cleanupCheckpoints();


### PR DESCRIPTION
## Summary
- add `--workspace-root` argument in the CLI entrypoint
- support passing the workspace root to `main`
- document the new flag
- test file resolution using a custom workspace root

## Testing
- `npm test --workspace packages/cli`

------
https://chatgpt.com/codex/tasks/task_e_686896446360833181aa3b5c3c9703e1