### PR TITLE
Handle nohup stdin

### DIFF
--- a/packages/cli/src/__tests__/nohup.test.ts
+++ b/packages/cli/src/__tests__/nohup.test.ts
@@ -1,0 +1,24 @@
+import { spawnSync } from 'node:child_process';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, it, expect } from 'vitest';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// Integration test for issue #3258.
+// Path to the bundled CLI used in integration tests
+const CLI_PATH = join(__dirname, '../../../bundle/gemini.js');
+
+describe('CLI launched with closed stdin', () => {
+  it('exits without EBADF when -p is provided', () => {
+    const result = spawnSync('node', [CLI_PATH, '-p', 'hello', '--telemetry=false'], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: { ...process.env, NO_UPDATE_NOTIFIER: '1', GEMINI_CLI_NO_RELAUNCH: '1' },
+    });
+
+    const stderr = result.stderr.toString();
+    expect(stderr).not.toMatch(/EBADF/);
+    // Missing API key will exit with code 1
+    expect(result.status).toBe(1);
+  });
+});

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -165,6 +165,7 @@ export async function main() {
     }
   }
   let input = config.getQuestion();
+  const hasPromptArg = Boolean(input && input.length > 0);
   const startupWarnings = await getStartupWarnings();
 
   // Render UI, passing necessary config values. Check that there is no command line question.
@@ -182,9 +183,9 @@ export async function main() {
     );
     return;
   }
-  // If not a TTY, read from stdin
+  // If not a TTY and no prompt was provided via -p, read from stdin
   // This is for cases where the user pipes input directly into the command
-  if (!process.stdin.isTTY) {
+  if (!process.stdin.isTTY && !hasPromptArg) {
     input += await readStdin();
   }
   if (!input) {


### PR DESCRIPTION
## Summary
- skip stdin reading when `-p` is used without a TTY
- add test verifying nohup execution with closed stdin

## Testing
- `npm test` in packages/cli

------
https://chatgpt.com/codex/tasks/task_e_6868964222e48331929d483adfd961c8