### PR TITLE
Fix typos (#3265)

### DIFF
--- a/packages/cli/src/ui/components/ThemeDialog.tsx
+++ b/packages/cli/src/ui/components/ThemeDialog.tsx
@@ -115,7 +115,7 @@ export function ThemeDialog({
     1,
   );
 
-  const DAILOG_PADDING = 2;
+  const DIALOG_PADDING = 2;
   const selectThemeHeight = themeItems.length + 1;
   const SCOPE_SELECTION_HEIGHT = 4; // Height for the scope selection section + margin.
   const SPACE_BETWEEN_THEME_SELECTION_AND_APPLY_TO = 1;
@@ -125,7 +125,7 @@ export function ThemeDialog({
   availableTerminalHeight -= TAB_TO_SELECT_HEIGHT;
 
   let totalLeftHandSideHeight =
-    DAILOG_PADDING +
+    DIALOG_PADDING +
     selectThemeHeight +
     SCOPE_SELECTION_HEIGHT +
     SPACE_BETWEEN_THEME_SELECTION_AND_APPLY_TO;
@@ -136,7 +136,7 @@ export function ThemeDialog({
   // Remove content from the LHS that can be omitted if it exceeds the available height.
   if (totalLeftHandSideHeight > availableTerminalHeight) {
     includePadding = false;
-    totalLeftHandSideHeight -= DAILOG_PADDING;
+    totalLeftHandSideHeight -= DIALOG_PADDING;
   }
 
   if (totalLeftHandSideHeight > availableTerminalHeight) {

--- a/packages/cli/src/ui/components/shared/MaxSizedBox.test.tsx
+++ b/packages/cli/src/ui/components/shared/MaxSizedBox.test.tsx
@@ -13,7 +13,7 @@ import { describe, it, expect } from 'vitest';
 describe('<MaxSizedBox />', () => {
   // Make sure MaxSizedBox logs errors on invalid configurations.
   // This is useful for debugging issues with the component.
-  // It should be set to false in production for perfornance and to avoid
+  // It should be set to false in production for performance and to avoid
   // cluttering the console if there are ignorable issues.
   setMaxSizedBoxDebugging(true);
 

--- a/packages/core/src/utils/errors.ts
+++ b/packages/core/src/utils/errors.ts
@@ -42,7 +42,7 @@ export function toFriendlyError(error: unknown): unknown {
         case 401:
           return new UnauthorizedError(data.error.message);
         case 403:
-          // It's import to pass the message here since it might
+          // It's important to pass the message here since it might
           // explain the cause like "the cloud project you're
           // using doesn't have code assist enabled".
           return new ForbiddenError(data.error.message);


### PR DESCRIPTION
## Summary
- fix typos in ThemeDialog component
- fix typo in MaxSizedBox tests
- fix typo in error helper

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68689640a99483318a8c3a0cf1f560fa