### PR TITLE
Ensure minute durations show seconds

### DIFF
--- a/packages/cli/src/ui/utils/formatters.test.ts
+++ b/packages/cli/src/ui/utils/formatters.test.ts
@@ -40,7 +40,7 @@ describe('formatters', () => {
     });
 
     it('should format an exact number of minutes', () => {
-      expect(formatDuration(120000)).toBe('2m');
+      expect(formatDuration(120000)).toBe('2m 0s');
     });
 
     it('should format a duration in minutes and seconds', () => {

--- a/packages/cli/src/ui/utils/formatters.ts
+++ b/packages/cli/src/ui/utils/formatters.ts
@@ -50,6 +50,8 @@ export const formatDuration = (milliseconds: number): string => {
   }
   if (seconds > 0) {
     parts.push(`${seconds}s`);
+  } else if (totalSeconds >= 60 && totalSeconds < 3600) {
+    parts.push('0s');
   }
 
   // If all parts are zero (e.g., exactly 1 hour), return the largest unit.


### PR DESCRIPTION
## Summary
- show `0s` for durations longer than a minute
- update formatters test
- empty commit referencing #2703

## Testing
- `npm test` *(fails: Failed to resolve entry for package `@google/gemini-cli-core`)*

------
https://chatgpt.com/codex/tasks/task_e_68689297de9883318de18a747fe6e019