### PR TITLE
Add .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,24 @@
+# Files and directories that should not be included in Docker context
+
+# Dependency directories
+node_modules
+packages/*/node_modules
+
+# Build artifacts
+bundle
+dist
+packages/*/dist
+packages/*/coverage
+
+# Generated files
+packages/cli/src/generated
+.integration-tests
+.docker
+
+# Environment files
+.env
+.env~
+
+# OS metadata
+.DS_Store
+Thumbs.db


### PR DESCRIPTION
## Summary
- prevent Docker build context from sending node_modules and build output

## Testing
- `npm run lint`
- `docker build .` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68689297aeb48331873d381d0142f921