### PR TITLE
Warn when running from root dir

### DIFF
--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -6,11 +6,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import './src/gemini.js';
-import { main } from './src/gemini.js';
+import { start } from './src/index.js';
 
 // --- Global Entry Point ---
-main().catch((error) => {
+start().catch((error) => {
   console.error('An unexpected critical error occurred:');
   if (error instanceof Error) {
     console.error(error.stack);

--- a/packages/cli/src/__tests__/rootWarning.test.ts
+++ b/packages/cli/src/__tests__/rootWarning.test.ts
@@ -1,0 +1,30 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { warnIfRootDir } from '../rootWarning.js';
+
+describe('warnIfRootDir', () => {
+  it('warns when cwd is unix root', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    warnIfRootDir('/');
+    expect(warnSpy).toHaveBeenCalledWith(
+      'Warning: Running Gemini CLI from the root directory. Consider running inside a project folder.',
+    );
+  });
+
+  it('warns when cwd is windows root', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    warnIfRootDir('C:/');
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  it('does not warn for project directory', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    warnIfRootDir('/home/user/project');
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,0 +1,13 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { main } from './gemini.js';
+import { warnIfRootDir } from './rootWarning.js';
+
+export async function start() {
+  warnIfRootDir();
+  await main();
+}

--- a/packages/cli/src/rootWarning.ts
+++ b/packages/cli/src/rootWarning.ts
@@ -1,0 +1,18 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Logs a warning if the CLI is started from a system root directory.
+ */
+export function warnIfRootDir(cwd: string = process.cwd()): void {
+  const isUnixRoot = cwd === '/';
+  const isWindowsRoot = /^[a-zA-Z]:[\\/]?$/.test(cwd);
+  if (isUnixRoot || isWindowsRoot) {
+    console.warn(
+      'Warning: Running Gemini CLI from the root directory. Consider running inside a project folder.',
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- warn if the CLI is started in `/` or a Windows drive root
- export startup helper and use it when starting the CLI
- test the root directory warning
- add a comment documenting the check

## Testing
- `npm run build --workspaces`
- `npm test --workspace=@google/gemini-cli`

------
https://chatgpt.com/codex/tasks/task_e_68689296c8ec8331be447a56890d8b55