### PR TITLE
docs: add Windows build guide

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -31,6 +31,7 @@ This documentation is organized into the following sections:
   - **[Web Search Tool](./tools/web-search.md):** Documentation for the `google_web_search` tool.
   - **[Memory Tool](./tools/memory.md):** Documentation for the `save_memory` tool.
 - **[Contributing & Development Guide](../CONTRIBUTING.md):** Information for contributors and developers, including setup, building, testing, and coding conventions.
+- **[Windows Build Guide](./windows-build.md):** Step-by-step instructions for building on Windows.
 - **[NPM Workspaces and Publishing](./npm.md):** Details on how the project's packages are managed and published.
 - **[Troubleshooting Guide](./troubleshooting.md):** Find solutions to common problems and FAQs.
 - **[Terms of Service and Privacy Notice](./tos-privacy.md):** Information on the terms of service and privacy notices applicable to your use of Gemini CLI.

--- a/docs/windows-build.md
+++ b/docs/windows-build.md
@@ -1,0 +1,41 @@
+# Building Gemini CLI on Windows
+
+This guide walks you through building the Gemini CLI from source on Windows. For a general overview of the project and features, see the [README](../README.md).
+
+## Prerequisites
+
+1. [Git for Windows](https://git-scm.com/download/win)
+2. [Node.js 18 or later](https://nodejs.org/en/download/)
+3. Optional: [pnpm](https://pnpm.io) if you prefer it over npm
+
+Verify that `git` and `node` are available in your command prompt by running `git --version` and `node --version`.
+
+## Steps
+
+1. Clone the repository:
+   ```cmd
+   git clone https://github.com/google-gemini/gemini-cli.git
+   cd gemini-cli
+   ```
+2. Install dependencies using either `npm` or `pnpm`:
+   ```cmd
+   npm ci
+   ```
+   or
+   ```cmd
+   pnpm install
+   ```
+3. Build the CLI:
+   ```cmd
+   npm run build
+   ```
+   To include the sandbox container, run:
+   ```cmd
+   npm run build:all
+   ```
+4. Start the CLI from the source directory:
+   ```cmd
+   npm start
+   ```
+
+After building, refer back to the [README](../README.md) for usage examples and troubleshooting tips.


### PR DESCRIPTION
## Summary
- add `docs/windows-build.md` guide for building on Windows
- reference the new guide from the docs index

## Testing
- `node -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686890af252c833197b63383b9b67cc5