### PR TITLE
Clarify npm PATH on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,13 @@ With the Gemini CLI you can:
    gemini
    ```
 
+   > **Windows users:** If the `gemini` command isn't found after installation,
+   > add your npm global `bin` folder to `PATH`. See
+   > [npm's guide to global installs](https://docs.npmjs.com/downloading-and-installing-packages-globally)
+   > for more info. Confirm the command is available with `where gemini`
+   > (or `which gemini` on Unix).
+
+
 3. **Pick a color theme**
 4. **Authenticate:** When prompted, sign in with your personal Google account. This will grant you up to 60 model requests per minute and 1,000 model requests per day using Gemini.
 


### PR DESCRIPTION
## Summary
- mention npm global PATH notes in README installation section
- reference npm docs on global installs

## Testing
- `npm run lint`
- `npm test` *(fails: Failed to resolve entry for package "@google/gemini-cli-core")*

------
https://chatgpt.com/codex/tasks/task_e_686890aeeaf48331984332a7a2b4dc0b