### PR TITLE
Add Homebrew installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,21 @@ With the Gemini CLI you can:
    npx https://github.com/google-gemini/gemini-cli
    ```
 
-   Or install it with:
+   Or install it globally with npm (see Homebrew below for an alternative):
 
    ```bash
    npm install -g @google/gemini-cli
    gemini
    ```
+
+### Install via Homebrew
+
+For macOS or Linux users who prefer [Homebrew](https://brew.sh/), run:
+
+```bash
+brew install google-gemini/gemini/gemini-cli
+gemini
+```
 
 3. **Pick a color theme**
 4. **Authenticate:** When prompted, sign in with your personal Google account. This will grant you up to 60 model requests per minute and 1,000 model requests per day using Gemini.

--- a/docs/Uninstall.md
+++ b/docs/Uninstall.md
@@ -1,6 +1,6 @@
 ## Uninstalling the CLI
 
-Your uninstall method depends on how you ran the CLI. Follow the instructions for either npx or a global npm installation.
+Your uninstall method depends on how you ran the CLI. Follow the instructions for npx, a global npm installation, or Homebrew.
 
 ### Method 1: Using npx
 
@@ -37,6 +37,14 @@ If you installed the CLI globally (e.g., `npm install -g @google/gemini-cli`), u
 
 ```bash
 npm uninstall -g @google/gemini-cli
+```
+
+### Method 3: Homebrew
+
+If you installed the CLI using Homebrew, remove it with:
+
+```bash
+brew uninstall gemini-cli
 ```
 
 This command completely removes the package from your system.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -10,7 +10,7 @@ There are several ways to run Gemini CLI. The option you choose depends on how y
 
 ### 1. Standard installation (Recommended for typical users)
 
-This is the recommended way for end-users to install Gemini CLI. It involves downloading the Gemini CLI package from the NPM registry.
+This is the recommended way for end-users to install Gemini CLI. It involves downloading the Gemini CLI package from the NPM registry or installing via Homebrew.
 
 - **Global install:**
 
@@ -19,6 +19,13 @@ This is the recommended way for end-users to install Gemini CLI. It involves dow
   npm install -g @google/gemini-cli
 
   # Now you can run the CLI from anywhere
+  gemini
+  ```
+
+- **Homebrew install:**
+
+  ```bash
+  brew install google-gemini/gemini/gemini-cli
   gemini
   ```
 

--- a/docs/npm.md
+++ b/docs/npm.md
@@ -6,7 +6,7 @@ This monorepo contains two main packages: `@google/gemini-cli` and `@google/gemi
 
 This is the main package for the Gemini CLI. It is responsible for the user interface, command parsing, and all other user-facing functionality.
 
-When this package is published, it is bundled into a single executable file. This bundle includes all of the package's dependencies, including `@google/gemini-cli-core`. This means that whether a user installs the package with `npm install -g @google/gemini-cli` or runs it directly with `npx @google/gemini-cli`, they are using this single, self-contained executable.
+When this package is published, it is bundled into a single executable file. This bundle includes all of the package's dependencies, including `@google/gemini-cli-core`. This means that whether a user installs the package with `npm install -g @google/gemini-cli`, runs it directly with `npx @google/gemini-cli`, or installs it via Homebrew (`brew install google-gemini/gemini/gemini-cli`), they are using this single, self-contained executable.
 
 ## `@google/gemini-cli-core`
 

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -9,6 +9,8 @@ Before using sandboxing, you need to install and set up the Gemini CLI:
 ```bash
 # install gemini-cli with npm
 npm install -g @google/gemini-cli
+# or use Homebrew
+brew install google-gemini/gemini/gemini-cli
 
 # Verify installation
 gemini --version

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -16,7 +16,7 @@ This guide provides solutions to common issues and debugging tips.
 ## Frequently asked questions (FAQs)
 
 - **Q: How do I update Gemini CLI to the latest version?**
-  - A: If installed globally via npm, update Gemini CLI using the command `npm install -g @google/gemini-cli@latest`. If run from source, pull the latest changes from the repository and rebuild using `npm run build`.
+  - A: If installed globally via npm, update Gemini CLI using the command `npm install -g @google/gemini-cli@latest`. If installed via Homebrew, run `brew upgrade google-gemini/gemini/gemini-cli`. If run from source, pull the latest changes from the repository and rebuild using `npm run build`.
 
 - **Q: Where are Gemini CLI configuration files stored?**
   - A: The CLI configuration is stored within two `settings.json` files: one in your home directory and one in your project's root directory. In both locations, `settings.json` is found in the `.gemini/` folder. Refer to [CLI Configuration](./cli/configuration.md) for more details.


### PR DESCRIPTION
## Summary
- document Homebrew installation in README and docs
- include brew usage as an alternative to npm and npx

## Testing
- `npm run preflight`

------
https://chatgpt.com/codex/tasks/task_e_686890ae92a88331aa7ef5c76da0a14d